### PR TITLE
feat: Bump module version to 0.7.0

### DIFF
--- a/foundry-local-rest-api/module.json
+++ b/foundry-local-rest-api/module.json
@@ -2,7 +2,7 @@
   "id": "foundry-local-rest-api",
   "title": "Foundry Local REST API",
   "description": "<p>A purely local REST API module for FoundryVTT that provides HTTP endpoints for external integrations without relying on third-party relay services. Enables secure, local-only access to actors, items, scenes, dice rolling, and world data.</p><p><strong>Features:</strong></p><ul><li>Local API key authentication</li><li>Actor and item search endpoints</li><li>Dice rolling API</li><li>Scene and world data access</li><li>No external dependencies</li></ul>",
-  "version": "0.4.4",
+  "version": "0.7.0",
   "compatibility": {
     "minimum": "11",
     "verified": "13"


### PR DESCRIPTION
Doing this manually to test the new version.
Need to figure out why release-please isn't bumping this.