### PR TITLE
fix: resolve issue #44 - WebSocket functionality not working properly

### DIFF
--- a/src/foundry/__tests__/client.test.ts
+++ b/src/foundry/__tests__/client.test.ts
@@ -269,7 +269,7 @@ describe('FoundryClient', () => {
 
       client = new FoundryClient({
         baseUrl: 'http://localhost:30000',
-        apiKey: 'test-api-key',
+        // No apiKey - this will use WebSocket mode
       });
     });
 

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -236,7 +236,19 @@ export class FoundryClient {
   private handleWebSocketMessage(message: any): void {
     logger.debug('WebSocket message received:', message);
 
-    // Handle different message types
+    // Call registered message handlers first
+    if (this.messageHandlers && this.messageHandlers.has(message.type)) {
+      const handler = this.messageHandlers.get(message.type);
+      if (handler) {
+        try {
+          handler(message.data);
+        } catch (error) {
+          logger.error('Error in message handler:', error);
+        }
+      }
+    }
+
+    // Handle built-in message types
     switch (message.type) {
       case 'combatUpdate':
         logger.info('Combat state updated');
@@ -683,35 +695,42 @@ export class FoundryClient {
 
     const wsUrl = this.config.baseUrl.replace(/^http/, 'ws') + '/socket.io/';
 
-    try {
-      this.ws = new WebSocket(wsUrl);
+    return new Promise((resolve, reject) => {
+      try {
+        this.ws = new WebSocket(wsUrl);
 
-      this.ws.on('open', () => {
-        logger.info('WebSocket connected to FoundryVTT');
-      });
+        this.ws.on('open', () => {
+          this._isConnected = true;
+          logger.info('WebSocket connected to FoundryVTT');
+          resolve();
+        });
 
-      this.ws.on('message', (data) => {
-        try {
-          const message = JSON.parse(data.toString());
-          this.handleWebSocketMessage(message);
-        } catch (error) {
-          logger.warn('Failed to parse WebSocket message:', error);
-        }
-      });
+        this.ws.on('message', (data) => {
+          try {
+            const message = JSON.parse(data.toString());
+            this.handleWebSocketMessage(message);
+          } catch (error) {
+            logger.warn('Failed to parse WebSocket message:', error);
+          }
+        });
 
-      this.ws.on('error', (error) => {
-        logger.error('WebSocket error:', error);
-      });
+        this.ws.on('error', (error) => {
+          logger.error('WebSocket error:', error);
+          this.ws = null;
+          this._isConnected = false;
+          reject(error);
+        });
 
-      this.ws.on('close', () => {
-        logger.info('WebSocket disconnected');
-        this.ws = null;
-        this._isConnected = false;
-      });
-    } catch (error) {
-      logger.error('WebSocket connection failed:', error);
-      throw error;
-    }
+        this.ws.on('close', () => {
+          logger.info('WebSocket disconnected');
+          this.ws = null;
+          this._isConnected = false;
+        });
+      } catch (error) {
+        logger.error('WebSocket connection failed:', error);
+        reject(error);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fixes WebSocket message sending, event handling, and connection error handling
- Ensures WebSocket tests properly test WebSocket functionality
- Implements proper Promise-based connection lifecycle

## Changes Made
- **Test Configuration Fix**: Remove `apiKey` from WebSocket tests to use WebSocket mode (src/foundry/__tests__/client.test.ts:272)
- **Message Handler Implementation**: Add proper callback system in `handleWebSocketMessage()` (src/foundry/client.ts:239-249)
- **Promise-based Connection**: Convert `connectWebSocket()` to Promise that resolves/rejects properly (src/foundry/client.ts:698-733)
- **Connection State Management**: Set `_isConnected = true` in WebSocket open handler (src/foundry/client.ts:703)
- **Error Handling**: Reject Promise on WebSocket connection errors (src/foundry/client.ts:717-722)

## Test Results
All WebSocket functionality tests now pass:
- ✅ **should send WebSocket messages** - Messages sent via `sendMessage()` now work
- ✅ **should handle WebSocket events** - Registered message handlers are properly called
- ✅ **should handle connection errors** - Connection errors properly reject the Promise

## Technical Details
The main issues were:
1. Tests had `apiKey` configured, which forced REST mode instead of WebSocket mode
2. `handleWebSocketMessage()` didn't invoke registered message handlers
3. `connectWebSocket()` didn't properly handle async connection lifecycle
4. Connection state not properly managed

## Fixes
Closes #44

🤖 Generated with [Claude Code](https://claude.ai/code)