### PR TITLE
fix: resolve integration test timeouts by adding missing apiKey confi…

### DIFF
--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -97,6 +97,7 @@ describe('Integration Tests', () => {
     it('should handle API operations with proper error handling', async () => {
       client = new FoundryClient({
         baseUrl: 'http://localhost:30000',
+        apiKey: 'test-key',
         retryAttempts: 2,
         retryDelay: 100,
       });
@@ -221,6 +222,7 @@ describe('Integration Tests', () => {
     it('should process complete actor search workflow', async () => {
       client = new FoundryClient({
         baseUrl: 'http://localhost:30000',
+        apiKey: 'test-key',
       });
 
       const mockAxios = await import('axios');
@@ -276,6 +278,7 @@ describe('Integration Tests', () => {
     it('should handle complex item search with filtering', async () => {
       client = new FoundryClient({
         baseUrl: 'http://localhost:30000',
+        apiKey: 'test-key',
       });
 
       const mockAxios = await import('axios');
@@ -333,6 +336,7 @@ describe('Integration Tests', () => {
     it('should handle cascading failures gracefully', async () => {
       client = new FoundryClient({
         baseUrl: 'http://localhost:30000',
+        apiKey: 'test-key',
         retryAttempts: 2,
         retryDelay: 10,
       });
@@ -360,6 +364,7 @@ describe('Integration Tests', () => {
     it('should maintain system stability after errors', async () => {
       client = new FoundryClient({
         baseUrl: 'http://localhost:30000',
+        apiKey: 'test-key',
         retryAttempts: 1,
       });
 


### PR DESCRIPTION
…guration

- Add apiKey: 'test-key' to integration tests that mock HTTP responses
- Prevents tests from attempting WebSocket connections to real servers
- Eliminates 5000ms timeout failures in integration test suite
- Tests now properly use mocked axios responses instead of real connections

Fixed timeout issues in:
- should handle API operations with proper error handling
- should process complete actor search workflow
- should handle complex item search with filtering
- should handle cascading failures gracefully
- should maintain system stability after errors

🤖 Generated with [Claude Code](https://claude.ai/code)