### PR TITLE
fix: resolve issue #44 - WebSocket functionality not working properly

### DIFF
--- a/src/foundry/__tests__/client.test.ts
+++ b/src/foundry/__tests__/client.test.ts
@@ -269,7 +269,7 @@ describe('FoundryClient', () => {
 
       client = new FoundryClient({
         baseUrl: 'http://localhost:30000',
-        apiKey: 'test-api-key',
+        // No apiKey - this will use WebSocket mode
       });
     });
 

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -236,7 +236,19 @@ export class FoundryClient {
   private handleWebSocketMessage(message: any): void {
     logger.debug('WebSocket message received:', message);
 
-    // Handle different message types
+    // Call registered message handlers first
+    if (this.messageHandlers && this.messageHandlers.has(message.type)) {
+      const handler = this.messageHandlers.get(message.type);
+      if (handler) {
+        try {
+          handler(message.data);
+        } catch (error) {
+          logger.error('Error in message handler:', error);
+        }
+      }
+    }
+
+    // Handle built-in message types
     switch (message.type) {
       case 'combatUpdate':
         logger.info('Combat state updated');
@@ -683,35 +695,42 @@ export class FoundryClient {
 
     const wsUrl = this.config.baseUrl.replace(/^http/, 'ws') + '/socket.io/';
 
-    try {
-      this.ws = new WebSocket(wsUrl);
+    return new Promise((resolve, reject) => {
+      try {
+        this.ws = new WebSocket(wsUrl);
 
-      this.ws.on('open', () => {
-        logger.info('WebSocket connected to FoundryVTT');
-      });
+        this.ws.on('open', () => {
+          this._isConnected = true;
+          logger.info('WebSocket connected to FoundryVTT');
+          resolve();
+        });
 
-      this.ws.on('message', (data) => {
-        try {
-          const message = JSON.parse(data.toString());
-          this.handleWebSocketMessage(message);
-        } catch (error) {
-          logger.warn('Failed to parse WebSocket message:', error);
-        }
-      });
+        this.ws.on('message', (data) => {
+          try {
+            const message = JSON.parse(data.toString());
+            this.handleWebSocketMessage(message);
+          } catch (error) {
+            logger.warn('Failed to parse WebSocket message:', error);
+          }
+        });
 
-      this.ws.on('error', (error) => {
-        logger.error('WebSocket error:', error);
-      });
+        this.ws.on('error', (error) => {
+          logger.error('WebSocket error:', error);
+          this.ws = null;
+          this._isConnected = false;
+          reject(error);
+        });
 
-      this.ws.on('close', () => {
-        logger.info('WebSocket disconnected');
-        this.ws = null;
-        this._isConnected = false;
-      });
-    } catch (error) {
-      logger.error('WebSocket connection failed:', error);
-      throw error;
-    }
+        this.ws.on('close', () => {
+          logger.info('WebSocket disconnected');
+          this.ws = null;
+          this._isConnected = false;
+        });
+      } catch (error) {
+        logger.error('WebSocket connection failed:', error);
+        reject(error);
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
- Fix WebSocket test configuration to use WebSocket mode (no apiKey)
- Implement proper message handler callback system in handleWebSocketMessage()
- Convert connectWebSocket() to Promise-based approach for proper error handling
- Set _isConnected flag correctly in WebSocket open handler
- Reject Promise on WebSocket connection errors

All WebSocket functionality tests now pass:
- ✅ should send WebSocket messages
- ✅ should handle WebSocket events
- ✅ should handle connection errors

🤖 Generated with [Claude Code](https://claude.ai/code)