### PR TITLE
fix: resolve integration test timeouts by adding missing apiKey configuration

### DIFF
--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -134,6 +134,18 @@ export class FoundryClient {
    * ```
    */
   constructor(config: FoundryClientConfig) {
+    // Validate required configuration
+    if (!config.baseUrl || config.baseUrl.trim() === '') {
+      throw new Error('baseUrl is required and cannot be empty');
+    }
+
+    // Basic URL validation
+    try {
+      new URL(config.baseUrl);
+    } catch (error) {
+      throw new Error(`Invalid baseUrl: ${config.baseUrl}`);
+    }
+
     this.config = {
       timeout: 10000,
       retryAttempts: 3,


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Fix integration test mock setup by using global mockAxiosInstance instead of local mocks
- Add proper mock chaining for connect() + API calls in error handling tests  
- Add URL validation to FoundryClient constructor for configuration test
- Ensure all integration tests use REST API mode with apiKey: 'test-key'
- Fix test expectations to account for connect() call in mock counts

## Test plan
- [x] All integration tests now pass
- [x] Error handling tests properly mock cascading failures 
- [x] Configuration validation test works with new URL validation
- [x] Mock setup uses global instance consistently across all tests

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)