### PR TITLE
fix: use brace-wrapped env var syntax in MCP config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -41,7 +41,7 @@
         "stdio"
       ],
       "env": {
-        "GITHUB_PERSONAL_ACCESS_TOKEN": "$GITHUB_PERSONAL_ACCESS_TOKEN"
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Fix environment variable syntax in `.mcp.json` from `$GITHUB_PERSONAL_ACCESS_TOKEN` to `${GITHUB_PERSONAL_ACCESS_TOKEN}` for consistent brace-wrapped expansion

## Test plan
- [x] Verify MCP server starts correctly with the updated config

🤖 Generated with [Claude Code](https://claude.com/claude-code)