### PR TITLE
docs: add ADRs, blueprint state, and write operations PRD

### DIFF
--- a/docs/adrs/0007-release-please-for-automated-releases.md
+++ b/docs/adrs/0007-release-please-for-automated-releases.md
@@ -1,0 +1,49 @@
+# ADR-007: release-please for Automated Release Management
+
+**Status**: Accepted
+**Date**: 2025-03-01 (commit 3146c38)
+**Confidence**: 9/10
+
+## Context
+
+The project needed a consistent, automated release process to:
+- Maintain a `CHANGELOG.md` from conventional commits
+- Bump `package.json` versions without manual edits
+- Create GitHub releases with release notes
+- Support multiple packages in the repository (MCP server + REST API module)
+
+## Decision
+
+Use [release-please](https://github.com/googleapis/release-please) via a GitHub Actions workflow with a manifest-based configuration (`release-please-config.json` + `.release-please-manifest.json`).
+
+Conventional commits drive version bumps automatically:
+- `feat:` → minor version bump
+- `fix:` → patch version bump
+- `feat!:` / `BREAKING CHANGE:` → major version bump
+
+## Evidence from Git History
+
+- `3146c38` `ci: configure release-please with manifest` — initial setup with manifest
+- Multiple `chore(main): release …` PRs created automatically by the bot
+- 20+ automated release PRs from v0.4.0 through v1.0.0
+- `a222434` `ci(release): add workflow_dispatch trigger` — manual trigger added for flexibility
+- `95b63dc` `chore(release): Refactor release-please config` — config simplified over time
+
+## Consequences
+
+**Positive:**
+- Zero-touch releases: merge a release PR to publish
+- CHANGELOG.md always up to date and machine-generated
+- Release history clearly tied to conventional commit scopes
+- Supports multi-package repositories via manifest
+
+**Negative:**
+- Requires strict conventional commit discipline from all contributors
+- release-please PRs can accumulate if releases are delayed
+- Manifest config can be tricky to set up initially (evidenced by multiple early fix commits)
+
+## Alternatives Considered
+
+- **Manual releases**: Rejected — error-prone and inconsistent
+- **semantic-release**: Similar capability but more complex plugin ecosystem
+- **standard-version**: Local-only, no GitHub Actions integration

--- a/docs/adrs/0008-npm-trusted-publishing-oidc.md
+++ b/docs/adrs/0008-npm-trusted-publishing-oidc.md
@@ -1,0 +1,50 @@
+# ADR-008: npm Trusted Publishing via OIDC
+
+**Status**: Accepted
+**Date**: 2026-03-07 (commit cf64b93, PR #113)
+**Confidence**: 9/10
+
+## Context
+
+Publishing to npm originally required a long-lived `NODE_AUTH_TOKEN` secret stored in GitHub repository secrets. This token is a security risk:
+- Tokens don't expire automatically
+- If compromised, can publish malicious packages
+- Must be manually rotated
+
+npm introduced [trusted publishing](https://docs.npmjs.com/generating-provenance-statements) via OIDC, which allows GitHub Actions to authenticate without any stored secrets.
+
+## Decision
+
+Replace `NODE_AUTH_TOKEN`-based npm authentication with OIDC trusted publishing:
+1. Configure the npm package on npmjs.com to trust GitHub Actions from this repository
+2. Use `npm publish` without a token — GitHub Actions OIDC provides authentication
+3. Require Node.js ≥ 24 (npm ≥ 11.5.1 required for OIDC publishing support)
+4. Remove `--provenance` flag (automatic with OIDC)
+
+## Evidence from Git History
+
+- `cf64b93` `feat(ci): migrate to npm trusted publishing (OIDC) (#113)` — full migration
+- `39a41f7` `feat(justfile): add npm-token and publish-dry-run recipes (#111)` — prior token-based tooling
+- `6f46e26` `chore: configure npm publishing via CI (#110)` — initial CI publishing setup
+
+Commit message body:
+> Replace token-based npm authentication with OIDC trusted publishing.
+> Remove NODE_AUTH_TOKEN and --provenance flag (automatic with OIDC)
+
+## Consequences
+
+**Positive:**
+- No long-lived secrets in GitHub repository settings
+- Provenance attestation is automatic and free
+- Reduces secret rotation burden
+- Aligned with npm security best practices
+
+**Negative:**
+- Requires npm package to be pre-configured on npmjs.com for trusted publishing
+- Requires Node.js 24+ in CI (minor constraint)
+- One-way migration — if OIDC support is removed from npm, manual rollback needed
+
+## Alternatives Considered
+
+- **Continue with NODE_AUTH_TOKEN**: Rejected — worse security posture, requires manual rotation
+- **GitHub Packages**: Rejected — poor discoverability for MCP server users vs npm public registry

--- a/docs/adrs/0009-package-rename-foundryvtt-mcp.md
+++ b/docs/adrs/0009-package-rename-foundryvtt-mcp.md
@@ -1,0 +1,51 @@
+# ADR-009: Package Rename to foundryvtt-mcp
+
+**Status**: Accepted
+**Date**: 2026-03-07 (commit fdc5b60, PR #114)
+**Confidence**: 9/10
+
+## Context
+
+The npm package was originally named `foundry-mcp-server`. Before the v1.0.0 public release on npm, the name needed review:
+- `foundry-mcp-server` is accurate but verbose and describes implementation (`server`) rather than purpose
+- The package is consumed as a CLI tool via `npx` or `bunx`, not as a library
+- The prefix `foundryvtt-` matches the FoundryVTT ecosystem convention (modules use `foundryvtt-` prefix)
+- A `bin` entry was needed to enable `npx -y foundryvtt-mcp` and `bunx foundryvtt-mcp` usage
+
+## Decision
+
+Rename the package from `foundry-mcp-server` to `foundryvtt-mcp` and add a `bin` entry pointing to the compiled entry point:
+
+```json
+{
+  "name": "foundryvtt-mcp",
+  "bin": {
+    "foundryvtt-mcp": "dist/index.js"
+  }
+}
+```
+
+## Evidence from Git History
+
+- `fdc5b60` `feat: rename package to foundryvtt-mcp and add bin entry (#114)` — full rename
+- Multiple earlier release tags use `foundry-mcp-server-v*` prefix (e.g., `foundry-mcp-server-v0.11.0`)
+- v1.0.0 release tag uses new prefix: `foundryvtt-mcp-v1.0.0`
+
+## Consequences
+
+**Positive:**
+- Matches FoundryVTT ecosystem naming conventions
+- Enables zero-install usage: `npx -y foundryvtt-mcp` and `bunx foundryvtt-mcp`
+- Shorter, more memorable name
+- Better discoverability on npm for users searching "foundryvtt"
+
+**Negative:**
+- Breaking change for anyone who added the package before v1.0.0 (pre-release, minimal user base)
+- Old package name `foundry-mcp-server` now orphaned on npm (unpublished)
+- Documentation and config examples needed updates
+
+## Alternatives Considered
+
+- **Keep foundry-mcp-server**: Rejected — less discoverable, inconsistent with ecosystem
+- **foundry-mcp**: Shorter but ambiguous; could refer to any Foundry product
+- **@foundryvtt/mcp**: Scoped package would require official Foundry org ownership

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,24 @@
+# Architecture Decision Records
+
+This directory contains ADRs for the foundryvtt-mcp project using [MADR format](https://adr.github.io/madr/).
+
+## Index
+
+| # | Title | Status | Date |
+|---|-------|--------|------|
+| [ADR-007](0007-release-please-for-automated-releases.md) | release-please for Automated Release Management | Accepted | 2025-03-01 |
+| [ADR-008](0008-npm-trusted-publishing-oidc.md) | npm Trusted Publishing via OIDC | Accepted | 2026-03-07 |
+| [ADR-009](0009-package-rename-foundryvtt-mcp.md) | Package Rename to foundryvtt-mcp | Accepted | 2026-03-07 |
+
+> **Note**: ADR-001 through ADR-006 are located in `docs/blueprint/adrs/` (earlier placement before blueprint standardization).
+> Future ADRs should be created in this directory (`docs/adrs/`).
+
+## Creating New ADRs
+
+```bash
+# Use blueprint to derive from discussions
+/blueprint:derive-adr
+
+# Or create manually following MADR format:
+# docs/adrs/{NNNN}-{kebab-case-title}.md
+```

--- a/docs/blueprint/README.md
+++ b/docs/blueprint/README.md
@@ -1,0 +1,17 @@
+# Blueprint Documentation
+
+This directory contains the blueprint state and documentation for this project.
+
+## Contents
+
+- `manifest.json` - Blueprint configuration and generated content tracking
+- `feature-tracker.json` - Feature tracking with tasks and progress
+- `work-orders/` - Task packages for subagents
+- `ai_docs/` - AI-generated documentation
+
+## Related Directories
+
+- `docs/prds/` - Product Requirements Documents
+- `docs/adrs/` - Architecture Decision Records
+- `docs/prps/` - Product Requirement Prompts
+- `.claude/rules/` - Generated rules (from blueprint)

--- a/docs/blueprint/feature-tracker.json
+++ b/docs/blueprint/feature-tracker.json
@@ -1,0 +1,181 @@
+{
+  "source_document": "docs/blueprint/prds/PRD-001-foundry-mcp-server-core.md",
+  "sync_targets": [],
+  "last_synced_at": null,
+  "features": [
+    {
+      "id": "FR-001",
+      "name": "Socket.IO authentication (4-step flow)",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "high"
+    },
+    {
+      "id": "FR-002",
+      "name": "World state cache (actors, items, scenes, journals, combat, users, messages)",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "high"
+    },
+    {
+      "id": "FR-003",
+      "name": "Dice rolling (RPG notation)",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "high"
+    },
+    {
+      "id": "FR-004",
+      "name": "Actor search and detail retrieval",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "high"
+    },
+    {
+      "id": "FR-005",
+      "name": "Item search",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "medium"
+    },
+    {
+      "id": "FR-006",
+      "name": "Scene information",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "medium"
+    },
+    {
+      "id": "FR-007",
+      "name": "Journal search and retrieval",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "medium"
+    },
+    {
+      "id": "FR-008",
+      "name": "Combat state and initiative tracking",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "medium"
+    },
+    {
+      "id": "FR-009",
+      "name": "User presence awareness",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "medium"
+    },
+    {
+      "id": "FR-010",
+      "name": "Chat message history",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "medium"
+    },
+    {
+      "id": "FR-011",
+      "name": "Full-text world search",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "medium"
+    },
+    {
+      "id": "FR-012",
+      "name": "World summary",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "medium"
+    },
+    {
+      "id": "FR-013",
+      "name": "NPC generation",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "low"
+    },
+    {
+      "id": "FR-014",
+      "name": "Loot table generation",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "low"
+    },
+    {
+      "id": "FR-015",
+      "name": "Rule lookup",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "low"
+    },
+    {
+      "id": "FR-016",
+      "name": "MCP resource endpoints (foundry://)",
+      "prd": "PRD-001",
+      "status": "complete",
+      "priority": "medium"
+    },
+    {
+      "id": "FR-017",
+      "name": "Optional REST API diagnostics (logs, health)",
+      "prd": "PRD-002",
+      "status": "complete",
+      "priority": "low"
+    },
+    {
+      "id": "FR-018",
+      "name": "Combat management (start/end, advance initiative)",
+      "prd": "PRD-001",
+      "status": "planned",
+      "priority": "high"
+    },
+    {
+      "id": "FR-019",
+      "name": "Token manipulation (move, status effects)",
+      "prd": "PRD-001",
+      "status": "planned",
+      "priority": "medium"
+    },
+    {
+      "id": "FR-020",
+      "name": "Scene navigation and switching",
+      "prd": "PRD-001",
+      "status": "planned",
+      "priority": "medium"
+    },
+    {
+      "id": "FR-021",
+      "name": "Character sheet editing",
+      "prd": "PRD-001",
+      "status": "planned",
+      "priority": "medium"
+    },
+    {
+      "id": "FR-022",
+      "name": "Journal creation and editing",
+      "prd": "PRD-001",
+      "status": "planned",
+      "priority": "low"
+    },
+    {
+      "id": "FR-023",
+      "name": "Macro execution",
+      "prd": "PRD-001",
+      "status": "planned",
+      "priority": "low"
+    },
+    {
+      "id": "FR-024",
+      "name": "Multi-world support",
+      "prd": "PRD-001",
+      "status": "planned",
+      "priority": "low"
+    }
+  ],
+  "summary": {
+    "total": 24,
+    "complete": 17,
+    "planned": 7,
+    "completion_percentage": 70.8
+  }
+}

--- a/docs/blueprint/manifest.json
+++ b/docs/blueprint/manifest.json
@@ -1,0 +1,133 @@
+{
+  "format_version": "3.2.0",
+  "created_at": "2026-03-03T00:00:00Z",
+  "updated_at": "2026-03-12T13:47:26Z",
+  "created_by": {
+    "blueprint_plugin": "3.2.0"
+  },
+  "project": {
+    "name": "foundryvtt-mcp",
+    "detected_stack": [
+      "typescript",
+      "node",
+      "bun",
+      "vitest",
+      "playwright",
+      "biome"
+    ]
+  },
+  "structure": {
+    "has_prds": true,
+    "has_adrs": true,
+    "has_prps": true,
+    "has_work_orders": true,
+    "has_ai_docs": true,
+    "has_modular_rules": true,
+    "has_feature_tracker": true,
+    "has_document_detection": true,
+    "claude_md_mode": "both"
+  },
+  "feature_tracker": {
+    "file": "feature-tracker.json",
+    "source_document": "docs/blueprint/prds/PRD-001-foundry-mcp-server-core.md",
+    "sync_targets": []
+  },
+  "generated": {
+    "rules": {},
+    "commands": {}
+  },
+  "custom_overrides": {
+    "skills": [],
+    "commands": []
+  },
+  "task_registry": {
+    "derive-prd": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "on-demand",
+      "stats": {},
+      "context": {}
+    },
+    "derive-plans": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": "2026-03-12T13:47:26Z",
+      "last_result": "success",
+      "schedule": "weekly",
+      "stats": {
+        "runs_total": 1,
+        "items_processed": 103,
+        "items_created": 5
+      },
+      "context": {
+        "commits_analyzed_up_to": "6708348c017c3cc314ad3bafd0de057aea170042",
+        "commits_analyzed_count": 103
+      }
+    },
+    "derive-rules": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "weekly",
+      "stats": {},
+      "context": {}
+    },
+    "generate-rules": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "on-change",
+      "stats": {},
+      "context": {}
+    },
+    "adr-validate": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "weekly",
+      "stats": {},
+      "context": {}
+    },
+    "feature-tracker-sync": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "daily",
+      "stats": {},
+      "context": {}
+    },
+    "sync-ids": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "on-change",
+      "stats": {},
+      "context": {}
+    },
+    "claude-md": {
+      "enabled": true,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "on-change",
+      "stats": {},
+      "context": {}
+    },
+    "curate-docs": {
+      "enabled": false,
+      "auto_run": false,
+      "last_completed_at": null,
+      "last_result": null,
+      "schedule": "on-demand",
+      "stats": {},
+      "context": {}
+    }
+  }
+}

--- a/docs/prds/write-operations.md
+++ b/docs/prds/write-operations.md
@@ -1,0 +1,166 @@
+# PRD-003: Write Operations — Game State Mutation
+
+**Status**: Planned
+**Created**: 2026-03-12
+**Source**: docs/blueprint/feature-tracker.json (FR-018 through FR-024)
+**Confidence**: 8/10
+
+## Overview
+
+Extend the foundryvtt-mcp server with write operations that allow AI assistants to actively participate in game sessions — not just observe. This includes combat management, token manipulation, scene navigation, character sheet editing, journal management, macro execution, and multi-world support.
+
+## Problem Statement
+
+The current implementation (v1.0.0) is entirely read-only. AI assistants can observe world state but cannot:
+- Take actions during combat (start/end combat, advance turns)
+- Move tokens or apply status effects
+- Navigate the GM between scenes
+- Edit character sheets or journal entries
+- Execute macros or custom scripts
+- Switch between worlds
+
+This limits the AI assistant role to "observer with suggestions" rather than "active collaborator."
+
+## Goals
+
+1. Enable AI assistants to take game-meaningful write actions during sessions
+2. Maintain backward compatibility — all read operations unchanged
+3. Implement proper authorization to prevent unintended mutations
+4. Support the most impactful write operations first (combat management)
+
+## Non-Goals
+
+- Full GM parity — not every FoundryVTT UI action needs an MCP tool
+- Real-time sync / reactive world updates (separate concern)
+- Multi-instance support (single server connection)
+
+## Features
+
+### FR-018: Combat Management (Priority: High)
+
+**As a** GM using an AI assistant,
+**I want** to start/end combat encounters and advance initiative via MCP tools,
+**So that** the AI can help manage encounter flow.
+
+Acceptance criteria:
+- `start_combat` — create a new combat encounter with selected tokens
+- `end_combat` — delete active combat encounter
+- `next_turn` — advance initiative to next combatant
+- `set_initiative` — set initiative score for a combatant
+- All tools require active combat to exist (return clear error otherwise)
+
+### FR-019: Token Manipulation (Priority: Medium)
+
+**As a** GM using an AI assistant,
+**I want** to move tokens and apply status effects,
+**So that** the AI can help narrate and mechanically represent scene outcomes.
+
+Acceptance criteria:
+- `move_token` — move a token to x,y coordinates on current scene
+- `apply_status_effect` — add/remove condition effects (Stunned, Prone, etc.)
+- `update_token` — update token properties (name, visibility, disposition)
+- Validates that token exists on current scene
+
+### FR-020: Scene Navigation (Priority: Medium)
+
+**As a** GM using an AI assistant,
+**I want** to switch the active scene,
+**So that** the AI can manage pacing and direct players to new locations.
+
+Acceptance criteria:
+- `activate_scene` — set a scene as the active (viewed) scene for all players
+- `preload_scene` — preload a scene without activating
+- Returns scene metadata on success
+
+### FR-021: Character Sheet Editing (Priority: Medium)
+
+**As a** GM or player using an AI assistant,
+**I want** to update actor attributes (HP, resources, currency),
+**So that** the AI can apply mechanical outcomes from narrative events.
+
+Acceptance criteria:
+- `update_actor` — partial update actor properties (hp, attributes, currency)
+- `add_item_to_actor` — add an item from world/compendium to actor inventory
+- `remove_item_from_actor` — remove item by id from actor
+- All updates via FoundryVTT's Socket.IO update events (not direct DB writes)
+
+### FR-022: Journal Creation and Editing (Priority: Low)
+
+**As a** GM using an AI assistant,
+**I want** to create and update journal entries,
+**So that** the AI can document session events, NPCs, and lore.
+
+Acceptance criteria:
+- `create_journal` — create new journal entry with title and content
+- `update_journal` — update journal entry page content
+- Content provided as HTML or Markdown (auto-converted)
+
+### FR-023: Macro Execution (Priority: Low)
+
+**As a** GM using an AI assistant,
+**I want** to execute FoundryVTT macros by name or ID,
+**So that** the AI can trigger complex scripted game effects.
+
+Acceptance criteria:
+- `execute_macro` — execute macro by name or id
+- Returns execution result or error
+- Security: only execute macros already present in the world (no arbitrary code injection)
+
+### FR-024: Multi-World Support (Priority: Low)
+
+**As a** server admin,
+**I want** to connect the MCP server to different worlds,
+**So that** I can use the AI assistant across multiple campaigns.
+
+Acceptance criteria:
+- `list_worlds` — list available worlds on the server
+- `switch_world` — disconnect from current world and reconnect to named world
+- Connection state properly reset between worlds
+
+## Technical Approach
+
+### Socket.IO Write Pattern
+
+FoundryVTT processes mutations via Socket.IO events. Write operations follow this pattern:
+
+```typescript
+socket.emit('modifyDocument', {
+  type: 'Actor',
+  action: 'update',
+  data: [{ _id: actorId, ...changes }]
+}, callback);
+```
+
+Key Socket.IO events for writes:
+- `modifyDocument` — create/update/delete documents
+- `activateScene` — scene navigation
+- `combat` — combat management (start/end/update)
+
+### Authorization
+
+- All write tools should check `FOUNDRY_WRITE_ENABLED=true` env var (default: false)
+- Operations must respect FoundryVTT's permission system (user role matters)
+- Potentially add per-tool enable/disable via env vars
+
+### Cache Invalidation
+
+After write operations, the in-memory cache will be stale. Options:
+1. Emit a `refreshWorldData` event internally after writes
+2. Accept stale cache with documentation (YAGNI for v1 writes)
+3. Subscribe to FoundryVTT's update events to patch cache incrementally
+
+Recommended: option 2 initially, document with `refresh_world_data` tool as the manual refresh.
+
+## Release Plan
+
+| Phase | Features | Version |
+|-------|----------|---------|
+| Phase 1 | FR-018 (combat), FR-019 (tokens) | v1.1.0 |
+| Phase 2 | FR-020 (scenes), FR-021 (characters) | v1.2.0 |
+| Phase 3 | FR-022 (journals), FR-023 (macros), FR-024 (multi-world) | v1.3.0+ |
+
+## Open Questions
+
+1. Should write operations require a separate, elevated API key?
+2. How to handle FoundryVTT permission errors gracefully (user lacks GM role)?
+3. Should `FOUNDRY_WRITE_ENABLED` be global or per-tool?

--- a/docs/prps/implement-write-operations.md
+++ b/docs/prps/implement-write-operations.md
@@ -1,0 +1,107 @@
+# PRP: Implement Write Operations
+
+**Source**: docs/prds/write-operations.md (PRD-003)
+**Priority**: High (FR-018), Medium (FR-019, FR-020, FR-021), Low (FR-022, FR-023, FR-024)
+**Confidence**: 8/10
+
+## Goal
+
+Add write operations to foundryvtt-mcp, starting with combat management (FR-018) as the highest-value first step.
+
+## Phase 1 Implementation Plan (FR-018 + FR-019)
+
+### Step 1: Add write guard
+
+Add `FOUNDRY_WRITE_ENABLED` env var to config:
+
+```typescript
+// src/config/index.ts
+FOUNDRY_WRITE_ENABLED: z.string().optional().transform(v => v === 'true'),
+```
+
+All write tool handlers check this at the start and return an error if false.
+
+### Step 2: Add Socket.IO write helper to FoundryClient
+
+```typescript
+// src/foundry/client.ts
+async emitWrite<T>(event: string, data: unknown): Promise<T> {
+  if (!this.config.FOUNDRY_WRITE_ENABLED) {
+    throw new Error('Write operations disabled. Set FOUNDRY_WRITE_ENABLED=true');
+  }
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error('Write timeout')), this.config.FOUNDRY_TIMEOUT);
+    this.socket.emit(event, data, (response: T) => {
+      clearTimeout(timeout);
+      resolve(response);
+    });
+  });
+}
+```
+
+### Step 3: Implement combat handler tools
+
+```typescript
+// src/tools/handlers/combat-write.ts
+export async function startCombat(client: FoundryClient, tokenIds: string[]): Promise<string>
+export async function endCombat(client: FoundryClient, combatId: string): Promise<void>
+export async function nextTurn(client: FoundryClient, combatId: string): Promise<CombatState>
+export async function setInitiative(client: FoundryClient, combatId: string, combatantId: string, initiative: number): Promise<void>
+```
+
+### Step 4: Implement token manipulation tools
+
+```typescript
+// src/tools/handlers/tokens.ts
+export async function moveToken(client: FoundryClient, tokenId: string, x: number, y: number): Promise<void>
+export async function applyStatusEffect(client: FoundryClient, tokenId: string, effect: string, active: boolean): Promise<void>
+```
+
+### Step 5: Register tool schemas
+
+Add to `src/tools/definitions.ts`:
+- `start_combat`, `end_combat`, `next_turn`, `set_initiative`
+- `move_token`, `apply_status_effect`
+
+### Step 6: Write unit tests
+
+```typescript
+// src/tools/handlers/__tests__/combat-write.test.ts
+// Mock socket.emit responses
+// Test: write guard blocks when disabled
+// Test: start_combat emits correct Socket.IO event
+// Test: error handling on Socket.IO failure
+```
+
+### Step 7: Update documentation
+
+- README: add "Write Operations" section with `FOUNDRY_WRITE_ENABLED` instructions
+- Add tool descriptions to API reference
+
+## Test Checklist
+
+- [ ] Unit: all write handlers tested with mocked Socket.IO
+- [ ] Unit: write guard returns error when `FOUNDRY_WRITE_ENABLED=false`
+- [ ] E2E: `start_combat` creates combat with correct tokens (requires live Foundry)
+- [ ] E2E: `next_turn` advances initiative correctly
+
+## Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `src/config/index.ts` | Add `FOUNDRY_WRITE_ENABLED` |
+| `src/foundry/client.ts` | Add `emitWrite()` helper |
+| `src/tools/handlers/combat-write.ts` | New file |
+| `src/tools/handlers/tokens.ts` | New file |
+| `src/tools/definitions.ts` | Add tool schemas |
+| `src/tools/registry.ts` | Register write tools |
+| `tests/unit/combat-write.test.ts` | New tests |
+| `README.md` | Document write ops |
+| `.env.example` | Add `FOUNDRY_WRITE_ENABLED=false` |
+
+## Success Criteria
+
+- All write tools disabled by default (`FOUNDRY_WRITE_ENABLED` not set)
+- All write tools documented with clear opt-in instructions
+- Unit test coverage ≥ 80% for new handlers
+- No regressions in existing read-only tools


### PR DESCRIPTION
## Summary

- **ADR-007–009**: Record architecture decisions for release-please, npm trusted publishing (OIDC), and package rename to `foundryvtt-mcp`
- **Blueprint state**: Add `manifest.json` and `feature-tracker.json` (structured JSON format) plus README
- **PRD-003 + PRP**: Write operations product requirements (combat management, token manipulation, scene navigation, character editing, journals, macros, multi-world) and phased implementation plan

## Test plan

- [ ] Verify all new files render correctly on GitHub
- [ ] Confirm ADR index links resolve to correct files
- [ ] Validate `feature-tracker.json` and `manifest.json` are valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)