### PR TITLE
feat(ci): add npm-publish smoke tests and fix bin entrypoint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,11 @@ jobs:
         FOUNDRY_URL: http://localhost:30000
         LOG_LEVEL: error
 
+    - name: Startup smoke test
+      run: bun run smoke
+
+    - name: Pack smoke test
+      run: bun run smoke:pack
+
     - name: Run linter
       run: bun run lint

--- a/README.md
+++ b/README.md
@@ -185,9 +185,13 @@ Ask your AI assistant things like:
 
 ## Troubleshooting
 
+The connectivity and setup helpers ship in the source tree (not the published `bin`), so run them from a dev checkout:
+
 ```bash
-bunx foundryvtt-mcp test-connection   # Test FoundryVTT connectivity
-bunx foundryvtt-mcp setup-wizard      # Re-run interactive setup
+git clone https://github.com/laurigates/foundryvtt-mcp.git
+cd foundryvtt-mcp && bun install
+bun run test-connection   # Probe FoundryVTT connectivity
+bun run setup-wizard      # Re-run interactive setup
 ```
 
 Detailed guide: [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
@@ -195,11 +199,13 @@ Detailed guide: [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
 ## Development
 
 ```bash
-bun run build          # Compile TypeScript
+bun run build          # Compile TypeScript and make dist/index.js executable
 bun run dev            # Development mode with hot reload
 bun test               # Unit tests (Vitest)
 bun run test:e2e       # E2E tests (Playwright)
 bun run lint           # Lint code (Biome)
+bun run smoke          # Startup smoke test against the local build
+bun run smoke:pack     # Pack-and-install smoke test (mirrors what npx consumers get)
 ```
 
 See [Development Guide](docs/guides/development.md) for project structure, adding tools, testing, and building.

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -46,6 +46,23 @@ npm run lint
 npm run test:e2e
 ```
 
+### Smoke tests
+
+Two smoke tests verify the server boots end-to-end without a live FoundryVTT.
+They run in CI on every PR and catch failure modes that the mocked Vitest
+suite cannot:
+
+```bash
+npm run smoke        # Spawn dist/index.js, verify the startup banner on stderr
+npm run smoke:pack   # npm pack -> install into a fresh consumer -> verify banner
+```
+
+`smoke` covers construction-time and import-time regressions (SDK shape
+changes, ESM resolution). `smoke:pack` additionally validates that the
+`package.json` `files` glob ships every runtime path the entrypoint needs —
+the kind of regression that only surfaces for users running `npx foundryvtt-mcp`
+or `bunx foundryvtt-mcp`, not for anyone running the source tree.
+
 ## Building
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
   },
   "type": "module",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && chmod +x dist/index.js",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
+    "smoke": "node scripts/smoke-test.js",
+    "smoke:pack": "node scripts/smoke-pack.js",
     "test": "vitest run",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest run --coverage",

--- a/scripts/smoke-pack.js
+++ b/scripts/smoke-pack.js
@@ -1,0 +1,299 @@
+#!/usr/bin/env node
+
+/**
+ * Pack-and-install smoke test.
+ *
+ * Validates the *published* package shape, not just the source build:
+ *   1. Every non-negation entry in `package.json` "files" resolves to a real
+ *      path (or matches at least one file via glob) in the source tree.
+ *   2. `npm pack` produces a tarball.
+ *   3. The tarball can be installed as a dependency in a fresh consumer
+ *      project.
+ *   4. `node node_modules/<pkg>/dist/index.js` from the consumer reaches the
+ *      startup banner — same contract as smoke-test.js.
+ *
+ * Catches packaging-shape regressions that smoke-test.js cannot: smoke-test
+ * runs against the source tree, where every file is present regardless of
+ * `files`. This script runs against the tarball end-users actually get via
+ * `bunx`/`npx foundryvtt-mcp` / `npm install foundryvtt-mcp`. The motivating
+ * scenario: shipping a release with a missing subdirectory in `files`, which
+ * crashes at startup with ERR_MODULE_NOT_FOUND only when consumers install it.
+ */
+
+import { spawn, spawnSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+const pkgJson = JSON.parse(readFileSync(join(repoRoot, 'package.json'), 'utf8'));
+
+const BANNER = '🎲 FoundryVTT MCP Server starting...';
+const STARTUP_TIMEOUT_MS = 5000;
+const SIGKILL_GRACE_MS = 2000;
+
+const cleanupPaths = [];
+function registerCleanup(path) {
+  cleanupPaths.push(path);
+}
+function cleanupAll() {
+  for (const path of cleanupPaths) {
+    rmSync(path, { recursive: true, force: true });
+  }
+}
+
+// Best-effort cleanup on interruption (Ctrl+C, CI cancellation, hangup).
+for (const sig of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+  process.on(sig, () => {
+    cleanupAll();
+    process.exit(1);
+  });
+}
+
+function fail(message, extra = '') {
+  console.error(`❌ smoke-pack failed: ${message}`);
+  if (extra) console.error(extra);
+  cleanupAll();
+  process.exit(1);
+}
+
+// ── 1. Validate `files` entries reference real paths or globs that match ──
+function walk(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const abs = join(dir, name);
+    const st = statSync(abs);
+    if (st.isDirectory()) out.push(...walk(abs));
+    else out.push(abs);
+  }
+  return out;
+}
+
+function globToRegExp(pattern) {
+  // Minimal glob -> regex: ** matches anything, * matches a single segment,
+  // ? matches a single char. Sufficient for typical "files" entries like
+  // "dist/**/*.js" or "build/handlers/".
+  let re = '';
+  for (let i = 0; i < pattern.length; i++) {
+    const c = pattern[i];
+    if (c === '*') {
+      if (pattern[i + 1] === '*') {
+        re += '.*';
+        i++;
+      } else {
+        re += '[^/]*';
+      }
+    } else if (c === '?') {
+      re += '[^/]';
+    } else if ('.+^$()|{}[]\\'.includes(c)) {
+      re += `\\${c}`;
+    } else {
+      re += c;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+function validateFilesEntries() {
+  const entries = pkgJson.files ?? [];
+  const checked = [];
+  for (const entry of entries) {
+    if (entry.startsWith('!')) continue;
+    const cleaned = entry.replace(/\/$/, '');
+    const hasGlob = /[*?[\]]/.test(cleaned);
+    if (!hasGlob) {
+      const absPath = join(repoRoot, cleaned);
+      if (!existsSync(absPath)) {
+        fail(
+          `package.json "files" entry "${entry}" references a path that does not exist: ${cleaned}`,
+        );
+      }
+      checked.push(entry);
+      continue;
+    }
+    // Glob — find the longest leading literal prefix and walk it.
+    const segments = cleaned.split('/');
+    const literalSegments = [];
+    for (const seg of segments) {
+      if (/[*?[\]]/.test(seg)) break;
+      literalSegments.push(seg);
+    }
+    const rootDir = join(repoRoot, ...literalSegments);
+    if (!existsSync(rootDir)) {
+      fail(`package.json "files" entry "${entry}" — root dir does not exist: ${rootDir}`);
+    }
+    const re = globToRegExp(cleaned);
+    const matches = walk(rootDir).some((abs) => re.test(relative(repoRoot, abs)));
+    if (!matches) {
+      fail(`package.json "files" entry "${entry}" matched zero files`);
+    }
+    checked.push(entry);
+  }
+  console.log(`✅ All ${checked.length} "files" entries reference existing paths or globs`);
+}
+
+// ── 2. Pack ───────────────────────────────────────────────────────────────
+function packTarball() {
+  const tmp = mkdtempSync(join(tmpdir(), 'foundryvtt-mcp-pack-'));
+  registerCleanup(tmp);
+  const result = spawnSync('npm', ['pack', '--pack-destination', tmp, '--json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+  if (result.status !== 0) {
+    fail(`npm pack failed (exit ${result.status})`, result.stderr);
+  }
+  let tarballName;
+  try {
+    const packInfo = JSON.parse(result.stdout);
+    tarballName = Array.isArray(packInfo) ? packInfo[0]?.filename : packInfo?.filename;
+  } catch (err) {
+    fail(`failed to parse npm pack --json output: ${err.message}`, result.stdout);
+  }
+  if (!tarballName) {
+    fail('npm pack did not report a tarball name', result.stdout);
+  }
+  const tarball = join(tmp, tarballName);
+  if (!existsSync(tarball)) {
+    fail(`reported tarball does not exist on disk: ${tarball}`);
+  }
+  console.log(`📦 Packed tarball: ${tarball}`);
+  return tarball;
+}
+
+// ── 3. Install into a fresh consumer project ──────────────────────────────
+function installInConsumer(tarball) {
+  const consumer = mkdtempSync(join(tmpdir(), 'foundryvtt-mcp-consumer-'));
+  registerCleanup(consumer);
+
+  // Minimal consumer package.json — avoids npm init prompts and lifecycle scripts.
+  writeFileSync(
+    join(consumer, 'package.json'),
+    `${JSON.stringify({ name: 'foundryvtt-mcp-pack-test', version: '0.0.0', private: true }, null, 2)}\n`,
+  );
+
+  const install = spawnSync(
+    'npm',
+    ['install', '--no-audit', '--no-fund', '--ignore-scripts', '--loglevel=error', tarball],
+    { cwd: consumer, encoding: 'utf8' },
+  );
+  if (install.status !== 0) {
+    fail(`npm install <tarball> failed (exit ${install.status})`, install.stderr);
+  }
+
+  const installedRoot = join(consumer, 'node_modules', pkgJson.name);
+  const serverPath = join(installedRoot, 'dist', 'index.js');
+  if (!existsSync(serverPath)) {
+    fail(`server entrypoint missing in installed package: ${serverPath}`);
+  }
+  console.log(`📥 Installed at: ${installedRoot}`);
+  return { consumer, serverPath };
+}
+
+// ── 4. Spawn the installed server and wait for the banner ────────────────
+function runInstalledServer({ consumer, serverPath }) {
+  return new Promise((resolve) => {
+    const child = spawn('node', [serverPath], {
+      cwd: consumer,
+      env: {
+        ...process.env,
+        FOUNDRY_URL: 'http://127.0.0.1:1',
+        FOUNDRY_USERNAME: 'smoke',
+        FOUNDRY_PASSWORD: 'smoke',
+        LOG_LEVEL: 'error',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stderr = '';
+    let stdout = '';
+    let resolved = false;
+    let bannerSeen = false;
+
+    const finish = (success, message) => {
+      if (resolved) return;
+      resolved = true;
+      clearTimeout(timeout);
+
+      const stillAlive = success && child.exitCode === null && child.signalCode === null;
+
+      if (success && stillAlive) {
+        console.log(`✅ Pack smoke test passed: ${message}`);
+        terminate(0);
+        return;
+      }
+
+      console.error(`❌ Pack smoke test failed: ${message}`);
+      if (stderr) {
+        console.error('--- stderr ---');
+        console.error(stderr);
+      }
+      if (stdout) {
+        console.error('--- stdout ---');
+        console.error(stdout);
+      }
+      terminate(1);
+    };
+
+    const terminate = (exitCode) => {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        cleanupAll();
+        if (exitCode !== 0) process.exit(exitCode);
+        resolve();
+        return;
+      }
+      child.kill('SIGTERM');
+      const killTimer = setTimeout(() => {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill('SIGKILL');
+        }
+      }, SIGKILL_GRACE_MS);
+      child.once('exit', () => {
+        clearTimeout(killTimer);
+        cleanupAll();
+        if (exitCode !== 0) process.exit(exitCode);
+        resolve();
+      });
+    };
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+      if (!bannerSeen && stderr.includes(BANNER)) {
+        bannerSeen = true;
+        finish(true, 'banner observed; process alive');
+      }
+    });
+    child.on('exit', (code, signal) => {
+      if (resolved) return;
+      finish(false, `server exited prematurely (code=${code}, signal=${signal})`);
+    });
+    child.on('error', (err) => {
+      if (resolved) return;
+      finish(false, `failed to spawn server: ${err.message}`);
+    });
+
+    const timeout = setTimeout(() => {
+      if (resolved) return;
+      finish(false, `timed out after ${STARTUP_TIMEOUT_MS}ms waiting for banner`);
+    }, STARTUP_TIMEOUT_MS);
+  });
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+validateFilesEntries();
+const tarball = packTarball();
+const installed = installInConsumer(tarball);
+await runInstalledServer(installed);

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+/**
+ * Startup smoke test for the built MCP server.
+ *
+ * Spawns `node dist/index.js` with placeholder env vars and verifies that:
+ *   1. The startup banner appears on stderr within a short timeout.
+ *   2. The process is still alive when the banner is observed.
+ *   3. The process can be terminated cleanly with SIGTERM.
+ *
+ * Exits 0 on success, non-zero on any failure. Designed to catch regressions
+ * in `new FoundryMCPServer()` initialisation that the existing service-mocked
+ * Vitest suite cannot detect (e.g. SDK API shape changes, Server constructor
+ * argument shape, ESM import-time failures).
+ *
+ * The test does NOT require a live FoundryVTT instance — the banner is emitted
+ * before `foundryClient.connect()` runs, so the inevitable connection failure
+ * against placeholder env vars happens *after* the smoke test has already
+ * observed the banner and SIGTERMed the child.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+const serverPath = join(repoRoot, 'dist', 'index.js');
+
+const BANNER = '🎲 FoundryVTT MCP Server starting...';
+const STARTUP_TIMEOUT_MS = 5000;
+const SIGKILL_GRACE_MS = 2000;
+
+if (!existsSync(serverPath)) {
+  console.error(`❌ Built server not found at ${serverPath}`);
+  console.error('   Run `bun run build` before invoking the smoke test.');
+  process.exit(2);
+}
+
+const child = spawn('node', [serverPath], {
+  cwd: repoRoot,
+  env: {
+    ...process.env,
+    FOUNDRY_URL: 'http://127.0.0.1:1',
+    FOUNDRY_USERNAME: 'smoke',
+    FOUNDRY_PASSWORD: 'smoke',
+    LOG_LEVEL: 'error',
+  },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+
+let stderr = '';
+let stdout = '';
+let resolved = false;
+let bannerSeen = false;
+
+child.stdout.on('data', (chunk) => {
+  stdout += chunk.toString();
+});
+
+child.stderr.on('data', (chunk) => {
+  stderr += chunk.toString();
+  if (!bannerSeen && stderr.includes(BANNER)) {
+    bannerSeen = true;
+    finish(true, 'banner observed; process alive');
+  }
+});
+
+child.on('exit', (code, signal) => {
+  if (resolved) return;
+  finish(false, `server exited prematurely (code=${code}, signal=${signal})`);
+});
+
+child.on('error', (err) => {
+  if (resolved) return;
+  finish(false, `failed to spawn server: ${err.message}`);
+});
+
+const timeout = setTimeout(() => {
+  if (resolved) return;
+  finish(false, `timed out after ${STARTUP_TIMEOUT_MS}ms waiting for banner`);
+}, STARTUP_TIMEOUT_MS);
+
+function finish(success, message) {
+  if (resolved) return;
+  resolved = true;
+  clearTimeout(timeout);
+
+  const stillAlive = success && child.exitCode === null && child.signalCode === null;
+
+  if (success && stillAlive) {
+    console.log(`✅ Smoke test passed: ${message}`);
+    terminate(0);
+    return;
+  }
+
+  console.error(`❌ Smoke test failed: ${message}`);
+  if (stderr) {
+    console.error('--- stderr ---');
+    console.error(stderr);
+  }
+  if (stdout) {
+    console.error('--- stdout ---');
+    console.error(stdout);
+  }
+  terminate(1);
+}
+
+function terminate(exitCode) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    process.exit(exitCode);
+    return;
+  }
+
+  child.kill('SIGTERM');
+  const killTimer = setTimeout(() => {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL');
+    }
+  }, SIGKILL_GRACE_MS);
+
+  child.once('exit', () => {
+    clearTimeout(killTimer);
+    process.exit(exitCode);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@
  * @see {@link https://foundryvtt.com/} FoundryVTT Virtual Tabletop
  */
 
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import {
@@ -210,6 +212,13 @@ class FoundryMCPServer {
 async function main(): Promise<void> {
   const server = new FoundryMCPServer();
 
+  // Pre-connect banner — emitted on stderr so the stdio JSON-RPC channel on
+  // stdout stays clean once StdioServerTransport.connect() takes it over.
+  // The smoke test (scripts/smoke-test.js) keys on this string to verify the
+  // binary loads without crashing at construction time, before any network
+  // call to FoundryVTT.
+  process.stderr.write('🎲 FoundryVTT MCP Server starting...\n');
+
   // Handle graceful shutdown
   process.on('SIGINT', async () => {
     logger.info('Received SIGINT, shutting down gracefully...');
@@ -241,8 +250,23 @@ async function main(): Promise<void> {
   }
 }
 
-// Start the server if this file is run directly
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Run the server if this file is executed directly.
+// Use realpath so the comparison works when npm/npx installs the bin as a
+// symlink into node_modules/.bin (the literal `file://${argv[1]}` compare
+// fails for symlinked invocations and on macOS where /tmp -> /private/tmp).
+const isMainModule = (() => {
+  const argv1 = process.argv[1];
+  if (!argv1) {
+    return false;
+  }
+  try {
+    return realpathSync(argv1) === fileURLToPath(import.meta.url);
+  } catch {
+    return import.meta.url === `file://${argv1}`;
+  }
+})();
+
+if (isMainModule) {
   main().catch((error) => {
     logger.error('Server startup failed:', error);
     process.exit(1);


### PR DESCRIPTION
## Summary

- Adds two smoke tests that verify the published package boots end-to-end without a live FoundryVTT, ported from the working pattern in [`podio-mcp`](https://github.com/forumviriumhelsinki/podio-mcp). Both run in CI on every PR.
- Fixes a latent bug surfaced by the pack smoke test: `bunx foundryvtt-mcp` / `npx foundryvtt-mcp` was silently exit-0'ing under symlinked invocations because the main-module check was a literal string compare.
- Corrects the README troubleshooting section, which claimed `bunx foundryvtt-mcp test-connection` worked when those scripts aren't in `bin`.

## Detail

### Smoke tests

| Script | Covers |
|---|---|
| `scripts/smoke-test.js` | Construction-time / ESM import regressions against the source build. Spawns `dist/index.js` with placeholder env, waits for a stderr banner, then SIGTERMs. |
| `scripts/smoke-pack.js` | Packaging-shape regressions only visible to npm/npx consumers. Validates each `files` glob, runs `npm pack`, installs into a fresh consumer project, runs the installed binary, waits for the banner. |

The mocked Vitest suite cannot catch either failure class — it never spawns the binary, and never sees the tarball.

### `bin` entrypoint fix

The previous main-module guard in `src/index.ts`:

```ts
if (import.meta.url === \`file://\${process.argv[1]}\`) {
  main()...
}
```

…fails whenever `process.argv[1]` is a symlink or differs from `import.meta.url` by symlink-resolution (npm/npx symlinks `bin` into `node_modules/.bin`; macOS `/tmp` -> `/private/tmp`). When the check fails the process exits 0 without ever calling `main()`, which is what `bunx foundryvtt-mcp` was doing in the wild. Switched to `realpathSync(argv[1]) === fileURLToPath(import.meta.url)` matching the pattern in `podio-mcp@2.5.x`.

### README fix

`bunx foundryvtt-mcp test-connection` / `setup-wizard` never worked — those tsx scripts aren't exposed via `bin`. Before this PR the symlinked `bunx` invocation silently exited; after this PR it would start the MCP server while ignoring the extra args. Replaced with a dev-checkout snippet that runs the scripts the way `package.json` actually exposes them (`bun run test-connection` / `bun run setup-wizard`).

## Test plan

- [x] `bun run build` succeeds (tsc + chmod)
- [x] `bun run test` — 102 unit tests pass, no regressions
- [x] `bun run lint` — back to baseline (0 errors, 10 pre-existing warnings)
- [x] `bun run smoke` — passes
- [x] `bun run smoke:pack` — packs tarball, installs into temp consumer, observes banner
- [ ] CI runs both smoke tests on this PR

## Provenance

The release-please workflow already publishes with `--provenance` since the repo is public — no change needed there. This PR strengthens the path that runs *before* publish, which is the gap that motivated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)