### PR TITLE
fix(ci): replace audit-ci with bun audit in security workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,7 +27,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Audit dependencies
-        run: npx audit-ci --moderate
+        run: bun audit --audit-level=moderate
 
   codeql:
     name: CodeQL Analysis


### PR DESCRIPTION
## Summary

- Replaces `npx audit-ci --moderate` with `bun audit --audit-level=moderate` in the Security workflow
- `audit-ci` fails with _"Cannot establish package-manager type, missing package-lock.json, yarn.lock, and pnpm-lock.yaml"_ because this project uses `bun.lock`
- `bun audit` reads `bun.lock` natively and reports the same vulnerability data via the npm advisory database

## Test plan

- [ ] Verify the `Dependency Audit` job passes on this PR's CI run
- [ ] Confirm `bun audit` exits 0 when no moderate+ vulnerabilities are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)