### PR TITLE
test(handlers): add unit tests for actors, combat, world handlers

### DIFF
--- a/src/tools/handlers/__tests__/actors.test.ts
+++ b/src/tools/handlers/__tests__/actors.test.ts
@@ -1,0 +1,182 @@
+/**
+ * @fileoverview Unit tests for actor handlers — search and get details
+ */
+
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it, vi } from 'vitest';
+import type { FoundryClient } from '../../../foundry/client.js';
+import type { ActorSearchResult, FoundryActor } from '../../../foundry/types.js';
+import { handleGetActorDetails, handleSearchActors } from '../actors.js';
+
+function getText(result: { content: Array<{ type: string; text: string }> }): string {
+  return result.content[0]?.text ?? '';
+}
+
+function buildActor(overrides: Partial<FoundryActor> = {}): FoundryActor {
+  return {
+    _id: 'actor-1',
+    name: 'Hero',
+    type: 'character',
+    level: 3,
+    hp: { value: 20, max: 25 },
+    ac: { value: 15 },
+    abilities: {
+      str: { value: 16, mod: 3 },
+      dex: { value: 14, mod: 2 },
+    },
+    ...overrides,
+  };
+}
+
+describe('handleSearchActors', () => {
+  it('returns a formatted list of actors on happy path', async () => {
+    const actors: FoundryActor[] = [
+      buildActor({ _id: 'a1', name: 'Aragorn', type: 'character', level: 5, hp: { value: 30, max: 40 } }),
+      buildActor({ _id: 'a2', name: 'Goblin', type: 'npc', level: 1, hp: { value: 7, max: 7 } }),
+    ];
+    const searchResult: ActorSearchResult = { actors, total: 2, page: 1, limit: 10 };
+    const client = {
+      searchActors: vi.fn().mockResolvedValue(searchResult),
+    } as unknown as FoundryClient;
+
+    const result = await handleSearchActors({ query: 'a' }, client);
+    const text = getText(result);
+
+    expect(client.searchActors).toHaveBeenCalledWith({ query: 'a', limit: 10 });
+    expect(text).toContain('Aragorn');
+    expect(text).toContain('Goblin');
+    expect(text).toContain('Level 5');
+    expect(text).toContain('HP: 30/40');
+    expect(text).toContain('**Results:** 2/2');
+  });
+
+  it('passes through type filter when supplied', async () => {
+    const searchResult: ActorSearchResult = { actors: [], total: 0, page: 1, limit: 5 };
+    const client = {
+      searchActors: vi.fn().mockResolvedValue(searchResult),
+    } as unknown as FoundryClient;
+
+    await handleSearchActors({ query: 'gob', type: 'npc', limit: 5 }, client);
+
+    expect(client.searchActors).toHaveBeenCalledWith({ query: 'gob', type: 'npc', limit: 5 });
+  });
+
+  it('shows "No actors found" placeholder on empty result', async () => {
+    const searchResult: ActorSearchResult = { actors: [], total: 0, page: 1, limit: 10 };
+    const client = {
+      searchActors: vi.fn().mockResolvedValue(searchResult),
+    } as unknown as FoundryClient;
+
+    const result = await handleSearchActors({ query: 'nonexistent' }, client);
+    const text = getText(result);
+
+    expect(text).toContain('No actors found matching the criteria.');
+    expect(text).toContain('**Results:** 0/0');
+  });
+
+  it('shows "All actors" when no query provided', async () => {
+    const searchResult: ActorSearchResult = { actors: [], total: 0, page: 1, limit: 10 };
+    const client = {
+      searchActors: vi.fn().mockResolvedValue(searchResult),
+    } as unknown as FoundryClient;
+
+    const result = await handleSearchActors({}, client);
+    const text = getText(result);
+
+    expect(text).toContain('**Query:** All actors');
+    expect(client.searchActors).toHaveBeenCalledWith({ query: '', limit: 10 });
+  });
+
+  it('falls back to "Unknown" when level and hp are missing', async () => {
+    const actors: FoundryActor[] = [buildActor({ name: 'Mystery', level: undefined, hp: undefined })];
+    const searchResult: ActorSearchResult = { actors, total: 1, page: 1, limit: 10 };
+    const client = {
+      searchActors: vi.fn().mockResolvedValue(searchResult),
+    } as unknown as FoundryClient;
+
+    const result = await handleSearchActors({ query: 'm' }, client);
+    const text = getText(result);
+
+    expect(text).toContain('Level Unknown');
+    expect(text).toContain('HP: Unknown/Unknown');
+  });
+
+  it('wraps client errors in McpError', async () => {
+    const client = {
+      searchActors: vi.fn().mockRejectedValue(new Error('boom')),
+    } as unknown as FoundryClient;
+
+    await expect(handleSearchActors({ query: 'x' }, client)).rejects.toThrow(McpError);
+  });
+});
+
+describe('handleGetActorDetails', () => {
+  it('returns formatted actor details on happy path', async () => {
+    const actor = buildActor({ name: 'Legolas', type: 'character', level: 7 });
+    const client = {
+      getActor: vi.fn().mockResolvedValue(actor),
+    } as unknown as FoundryClient;
+
+    const result = await handleGetActorDetails({ actorId: 'actor-1' }, client);
+    const text = getText(result);
+
+    expect(client.getActor).toHaveBeenCalledWith('actor-1');
+    expect(text).toContain('Legolas');
+    expect(text).toContain('**Type:** character');
+    expect(text).toContain('**Level:** 7');
+    expect(text).toContain('**Hit Points:** 20/25');
+    expect(text).toContain('**Armor Class:** 15');
+    expect(text).toContain('**STR:** 16 (+3)');
+    expect(text).toContain('**DEX:** 14 (+2)');
+  });
+
+  it('throws McpError with InvalidParams when actorId is missing', async () => {
+    const client = { getActor: vi.fn() } as unknown as FoundryClient;
+
+    await expect(handleGetActorDetails({ actorId: '' }, client)).rejects.toThrow(McpError);
+    expect(client.getActor).not.toHaveBeenCalled();
+  });
+
+  it('throws McpError when actorId is not a string', async () => {
+    const client = { getActor: vi.fn() } as unknown as FoundryClient;
+
+    await expect(
+      handleGetActorDetails({ actorId: 123 as unknown as string }, client),
+    ).rejects.toThrow(McpError);
+    expect(client.getActor).not.toHaveBeenCalled();
+  });
+
+  it('shows fallback text when abilities are missing', async () => {
+    const actor = buildActor({ abilities: undefined });
+    const client = {
+      getActor: vi.fn().mockResolvedValue(actor),
+    } as unknown as FoundryClient;
+
+    const result = await handleGetActorDetails({ actorId: 'actor-1' }, client);
+    const text = getText(result);
+
+    expect(text).toContain('No ability scores available');
+  });
+
+  it('formats negative ability modifiers without an extra sign', async () => {
+    const actor = buildActor({
+      abilities: { str: { value: 8, mod: -1 } },
+    });
+    const client = {
+      getActor: vi.fn().mockResolvedValue(actor),
+    } as unknown as FoundryClient;
+
+    const result = await handleGetActorDetails({ actorId: 'actor-1' }, client);
+    const text = getText(result);
+
+    expect(text).toContain('**STR:** 8 (-1)');
+  });
+
+  it('wraps fetch errors in McpError', async () => {
+    const client = {
+      getActor: vi.fn().mockRejectedValue(new Error('not found')),
+    } as unknown as FoundryClient;
+
+    await expect(handleGetActorDetails({ actorId: 'actor-1' }, client)).rejects.toThrow(McpError);
+  });
+});

--- a/src/tools/handlers/__tests__/combat.test.ts
+++ b/src/tools/handlers/__tests__/combat.test.ts
@@ -1,0 +1,178 @@
+/**
+ * @fileoverview Unit tests for combat handler — get_combat_state
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { FoundryClient } from '../../../foundry/client.js';
+import type { WorldActor, WorldCombat } from '../../../foundry/types.js';
+import { handleGetCombatState } from '../combat.js';
+
+function getText(result: { content: Array<{ type: string; text: string }> }): string {
+  return result.content[0]?.text ?? '';
+}
+
+type Combatant = WorldCombat['combatants'][number];
+
+function buildCombatant(overrides: Partial<Combatant> = {}): Combatant {
+  return {
+    _id: 'c1',
+    name: 'Goblin',
+    initiative: 10,
+    hidden: false,
+    defeated: false,
+    ...overrides,
+  };
+}
+
+function buildCombat(overrides: Partial<WorldCombat> = {}): WorldCombat {
+  return {
+    _id: 'combat-1',
+    active: true,
+    round: 1,
+    turn: 0,
+    started: true,
+    combatants: [],
+    ...overrides,
+  };
+}
+
+describe('handleGetCombatState', () => {
+  it('returns "No active combat encounter." when no combat exists', async () => {
+    const client = {
+      getCombatState: vi.fn().mockReturnValue(null),
+    } as unknown as FoundryClient;
+
+    const result = await handleGetCombatState({}, client);
+    const text = getText(result);
+
+    expect(text).toBe('No active combat encounter.');
+    expect(client.getCombatState).toHaveBeenCalled();
+  });
+
+  it('formats active combat with combatants sorted by initiative desc', async () => {
+    const combat = buildCombat({
+      round: 3,
+      turn: 0,
+      combatants: [
+        buildCombatant({ _id: 'a', name: 'Bob', initiative: 5 }),
+        buildCombatant({ _id: 'b', name: 'Alice', initiative: 18 }),
+        buildCombatant({ _id: 'c', name: 'Charlie', initiative: 12 }),
+      ],
+    });
+    const client = {
+      getCombatState: vi.fn().mockReturnValue(combat),
+      getRawActor: vi.fn().mockReturnValue(undefined),
+    } as unknown as FoundryClient;
+
+    const result = await handleGetCombatState({}, client);
+    const text = getText(result);
+
+    expect(text).toContain('Round 3');
+    // Alice (init 18) comes first
+    const aliceIdx = text.indexOf('Alice');
+    const charlieIdx = text.indexOf('Charlie');
+    const bobIdx = text.indexOf('Bob');
+    expect(aliceIdx).toBeGreaterThan(-1);
+    expect(aliceIdx).toBeLessThan(charlieIdx);
+    expect(charlieIdx).toBeLessThan(bobIdx);
+    expect(text).toContain('1. [18] **Alice**');
+    expect(text).toContain('2. [12] **Charlie**');
+    expect(text).toContain('3. [5] **Bob**');
+    // turn 0 corresponds to the first combatant by sorted order (Alice)
+    expect(text).toMatch(/1\. \[18\] \*\*Alice\*\*.*<-- CURRENT/);
+  });
+
+  it('renders "?" for null initiative', async () => {
+    const combat = buildCombat({
+      combatants: [buildCombatant({ name: 'Sneaky', initiative: null })],
+    });
+    const client = {
+      getCombatState: vi.fn().mockReturnValue(combat),
+      getRawActor: vi.fn().mockReturnValue(undefined),
+    } as unknown as FoundryClient;
+
+    const result = await handleGetCombatState({}, client);
+    const text = getText(result);
+
+    expect(text).toContain('[?] **Sneaky**');
+  });
+
+  it('marks defeated and hidden combatants with status flags', async () => {
+    const combat = buildCombat({
+      combatants: [
+        buildCombatant({ name: 'Fallen', initiative: 10, defeated: true }),
+        buildCombatant({ name: 'Lurker', initiative: 8, hidden: true }),
+      ],
+    });
+    const client = {
+      getCombatState: vi.fn().mockReturnValue(combat),
+      getRawActor: vi.fn().mockReturnValue(undefined),
+    } as unknown as FoundryClient;
+
+    const result = await handleGetCombatState({}, client);
+    const text = getText(result);
+
+    expect(text).toContain('Fallen');
+    expect(text).toContain('[DEFEATED]');
+    expect(text).toContain('Lurker');
+    expect(text).toContain('[HIDDEN]');
+  });
+
+  it('appends HP/AC from raw actor when actorId resolves', async () => {
+    const combat = buildCombat({
+      combatants: [buildCombatant({ name: 'Orc', initiative: 12, actorId: 'actor-99' })],
+    });
+    const rawActor: WorldActor = {
+      _id: 'actor-99',
+      name: 'Orc',
+      type: 'npc',
+      system: {
+        attributes: {
+          hp: { value: 12, max: 20 },
+          ac: { value: 14 },
+        },
+      },
+    };
+    const client = {
+      getCombatState: vi.fn().mockReturnValue(combat),
+      getRawActor: vi.fn().mockReturnValue(rawActor),
+    } as unknown as FoundryClient;
+
+    const result = await handleGetCombatState({}, client);
+    const text = getText(result);
+
+    expect(client.getRawActor).toHaveBeenCalledWith('actor-99');
+    expect(text).toContain('HP: 12/20');
+    expect(text).toContain('AC: 14');
+  });
+
+  it('omits HP/AC when raw actor lookup returns undefined', async () => {
+    const combat = buildCombat({
+      combatants: [buildCombatant({ name: 'Ghost', initiative: 7, actorId: 'missing-id' })],
+    });
+    const client = {
+      getCombatState: vi.fn().mockReturnValue(combat),
+      getRawActor: vi.fn().mockReturnValue(undefined),
+    } as unknown as FoundryClient;
+
+    const result = await handleGetCombatState({}, client);
+    const text = getText(result);
+
+    expect(text).toContain('Ghost');
+    expect(text).not.toContain('HP:');
+    expect(text).not.toContain('AC:');
+  });
+
+  it('handles empty combatant list gracefully', async () => {
+    const combat = buildCombat({ round: 2, combatants: [] });
+    const client = {
+      getCombatState: vi.fn().mockReturnValue(combat),
+      getRawActor: vi.fn().mockReturnValue(undefined),
+    } as unknown as FoundryClient;
+
+    const result = await handleGetCombatState({}, client);
+    const text = getText(result);
+
+    expect(text).toContain('Round 2');
+  });
+});

--- a/src/tools/handlers/__tests__/world.test.ts
+++ b/src/tools/handlers/__tests__/world.test.ts
@@ -1,0 +1,254 @@
+/**
+ * @fileoverview Unit tests for world handlers — search, summary, refresh
+ */
+
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it, vi } from 'vitest';
+import type { FoundryClient } from '../../../foundry/client.js';
+import type {
+  FoundryWorld,
+  WorldActor,
+  WorldItem,
+  WorldJournal,
+  WorldScene,
+} from '../../../foundry/types.js';
+import {
+  handleGetWorldSummary,
+  handleRefreshWorldData,
+  handleSearchWorld,
+} from '../world.js';
+
+function getText(result: { content: Array<{ type: string; text: string }> }): string {
+  return result.content[0]?.text ?? '';
+}
+
+function buildActor(name: string, type = 'character'): WorldActor {
+  return { _id: `a-${name}`, name, type, system: {} };
+}
+
+function buildItem(name: string, type = 'weapon'): WorldItem {
+  return { _id: `i-${name}`, name, type, system: {} };
+}
+
+function buildScene(name: string, active = false): WorldScene {
+  return {
+    _id: `s-${name}`,
+    name,
+    active,
+    navigation: true,
+    width: 0,
+    height: 0,
+    padding: 0,
+    darkness: 0,
+    globalLight: false,
+  };
+}
+
+function buildJournal(name: string): WorldJournal {
+  return { _id: `j-${name}`, name };
+}
+
+describe('handleSearchWorld', () => {
+  it('formats results across all collections on happy path', async () => {
+    const client = {
+      searchWorld: vi.fn().mockReturnValue({
+        actors: [buildActor('Wizard')],
+        items: [buildItem('Wand')],
+        scenes: [buildScene('Tower', true)],
+        journals: [buildJournal('Lore')],
+      }),
+    } as unknown as FoundryClient;
+
+    const result = await handleSearchWorld({ query: 'w' }, client);
+    const text = getText(result);
+
+    expect(client.searchWorld).toHaveBeenCalledWith('w');
+    expect(text).toContain('**World Search** — "w"');
+    expect(text).toContain('**Actors** (1)');
+    expect(text).toContain('Wizard (character)');
+    expect(text).toContain('**Items** (1)');
+    expect(text).toContain('Wand (weapon)');
+    expect(text).toContain('**Scenes** (1)');
+    expect(text).toContain('Tower [ACTIVE]');
+    expect(text).toContain('**Journals** (1)');
+    expect(text).toContain('Lore');
+  });
+
+  it('limits each section to the configured limit (default 5)', async () => {
+    const actors = Array.from({ length: 10 }, (_, i) => buildActor(`A${i}`));
+    const client = {
+      searchWorld: vi.fn().mockReturnValue({
+        actors,
+        items: [],
+        scenes: [],
+        journals: [],
+      }),
+    } as unknown as FoundryClient;
+
+    const result = await handleSearchWorld({ query: 'a' }, client);
+    const text = getText(result);
+
+    // header reports total (10), but only 5 entries are listed
+    expect(text).toContain('**Actors** (10)');
+    const listedActors = text.split('\n').filter((line) => line.startsWith('  - A'));
+    expect(listedActors).toHaveLength(5);
+  });
+
+  it('respects an explicit limit override', async () => {
+    const actors = Array.from({ length: 10 }, (_, i) => buildActor(`A${i}`));
+    const client = {
+      searchWorld: vi.fn().mockReturnValue({
+        actors,
+        items: [],
+        scenes: [],
+        journals: [],
+      }),
+    } as unknown as FoundryClient;
+
+    const result = await handleSearchWorld({ query: 'a', limit: 2 }, client);
+    const text = getText(result);
+
+    const listedActors = text.split('\n').filter((line) => line.startsWith('  - A'));
+    expect(listedActors).toHaveLength(2);
+  });
+
+  it('returns a "no results" message when all collections are empty', async () => {
+    const client = {
+      searchWorld: vi.fn().mockReturnValue({ actors: [], items: [], scenes: [], journals: [] }),
+    } as unknown as FoundryClient;
+
+    const result = await handleSearchWorld({ query: 'zzz' }, client);
+    const text = getText(result);
+
+    expect(text).toBe('No results found for "zzz".');
+  });
+
+  it('omits sections that have no matches', async () => {
+    const client = {
+      searchWorld: vi.fn().mockReturnValue({
+        actors: [buildActor('Hero')],
+        items: [],
+        scenes: [],
+        journals: [],
+      }),
+    } as unknown as FoundryClient;
+
+    const result = await handleSearchWorld({ query: 'h' }, client);
+    const text = getText(result);
+
+    expect(text).toContain('**Actors** (1)');
+    expect(text).not.toContain('**Items**');
+    expect(text).not.toContain('**Scenes**');
+    expect(text).not.toContain('**Journals**');
+  });
+
+  it('wraps client errors in McpError', async () => {
+    const client = {
+      searchWorld: vi.fn(() => {
+        throw new Error('boom');
+      }),
+    } as unknown as FoundryClient;
+
+    await expect(handleSearchWorld({ query: 'a' }, client)).rejects.toThrow(McpError);
+  });
+});
+
+describe('handleGetWorldSummary', () => {
+  it('returns formatted world info and counts on happy path', async () => {
+    const worldInfo: FoundryWorld = {
+      id: 'world-1',
+      title: 'My Campaign',
+      description: '',
+      system: 'dnd5e',
+      coreVersion: '13.348',
+      systemVersion: '4.0.0',
+      playtime: 0,
+      created: '',
+      modified: '',
+    };
+    const client = {
+      getWorldInfo: vi.fn().mockResolvedValue(worldInfo),
+      getWorldSummary: vi.fn().mockReturnValue({ actors: 12, items: 50 }),
+    } as unknown as FoundryClient;
+
+    const result = await handleGetWorldSummary({}, client);
+    const text = getText(result);
+
+    expect(text).toContain('**World: My Campaign**');
+    expect(text).toContain('**System:** dnd5e (4.0.0)');
+    expect(text).toContain('**Core Version:** 13.348');
+    expect(text).toContain('- **actors**: 12');
+    expect(text).toContain('- **items**: 50');
+  });
+
+  it('shows fallback when summary returns no entries', async () => {
+    const worldInfo: FoundryWorld = {
+      id: 'world-1',
+      title: 'Empty',
+      description: '',
+      system: 'dnd5e',
+      coreVersion: '13.0',
+      systemVersion: '4.0',
+      playtime: 0,
+      created: '',
+      modified: '',
+    };
+    const client = {
+      getWorldInfo: vi.fn().mockResolvedValue(worldInfo),
+      getWorldSummary: vi.fn().mockReturnValue({}),
+    } as unknown as FoundryClient;
+
+    const result = await handleGetWorldSummary({}, client);
+    const text = getText(result);
+
+    expect(text).toContain('No data available — not connected.');
+  });
+
+  it('wraps getWorldInfo errors in McpError', async () => {
+    const client = {
+      getWorldInfo: vi.fn().mockRejectedValue(new Error('offline')),
+      getWorldSummary: vi.fn().mockReturnValue({}),
+    } as unknown as FoundryClient;
+
+    await expect(handleGetWorldSummary({}, client)).rejects.toThrow(McpError);
+  });
+});
+
+describe('handleRefreshWorldData', () => {
+  it('calls refresh and reports the new collection counts', async () => {
+    const refresh = vi.fn().mockResolvedValue(undefined);
+    const client = {
+      refreshWorldData: refresh,
+      getWorldSummary: vi.fn().mockReturnValue({ actors: 3, items: 7 }),
+    } as unknown as FoundryClient;
+
+    const result = await handleRefreshWorldData({}, client);
+    const text = getText(result);
+
+    expect(refresh).toHaveBeenCalled();
+    expect(text).toContain('World data refreshed successfully.');
+    expect(text).toContain('- **actors**: 3');
+    expect(text).toContain('- **items**: 7');
+  });
+
+  it('wraps refresh errors in McpError', async () => {
+    const client = {
+      refreshWorldData: vi.fn().mockRejectedValue(new Error('socket lost')),
+      getWorldSummary: vi.fn().mockReturnValue({}),
+    } as unknown as FoundryClient;
+
+    await expect(handleRefreshWorldData({}, client)).rejects.toThrow(McpError);
+  });
+
+  it('produces a result even when getWorldSummary returns no entries', async () => {
+    const client = {
+      refreshWorldData: vi.fn().mockResolvedValue(undefined),
+      getWorldSummary: vi.fn().mockReturnValue({}),
+    } as unknown as FoundryClient;
+
+    const result = await handleRefreshWorldData({}, client);
+    const text = getText(result);
+
+    expect(text).toContain('World data refreshed successfully.');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds unit tests for three handlers in \`src/tools/handlers/__tests__/\`:
  - \`actors.test.ts\` — 12 tests (search_actors + get_actor_details)
  - \`combat.test.ts\` — 7 tests (initiative sort, defeated/hidden flags, HP/AC enrichment, missing combatants)
  - \`world.test.ts\` — 12 tests (search_world cross-collection, get_world_summary, refresh_world_data)
- 3 commits, one per handler.
- Total **31 new tests**, all green via \`npx vitest run\`. \`tsc --noEmit\` clean.

## Why

Per #134 — these handlers had zero unit-test coverage. Tests follow the inline-mock-FoundryClient pattern established by \`chat.test.ts\` and \`diagnostics.test.ts\` from earlier PRs.

Refs #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)