### PR TITLE
test(handlers): add unit tests for dice, generation, items, journals, search_logs

### DIFF
--- a/src/tools/handlers/__tests__/dice.test.ts
+++ b/src/tools/handlers/__tests__/dice.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview Unit tests for dice handler — roll_dice formatting
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { FoundryClient } from '../../../foundry/client.js';
+import { handleRollDice } from '../dice.js';
+
+interface MockDiceRoll {
+  formula: string;
+  total: number;
+  breakdown: string;
+  reason?: string;
+  timestamp: string;
+}
+
+function mockFoundryClient(roll: MockDiceRoll): FoundryClient {
+  return {
+    rollDice: vi.fn(async (_formula: string, _reason?: string) => roll),
+  } as unknown as FoundryClient;
+}
+
+function getText(result: Awaited<ReturnType<typeof handleRollDice>>): string {
+  return (result as { content: Array<{ type: string; text: string }> }).content[0]?.text ?? '';
+}
+
+describe('handleRollDice', () => {
+  describe('happy path', () => {
+    it('returns formatted result for a basic d20 roll', async () => {
+      const client = mockFoundryClient({
+        formula: '1d20',
+        total: 14,
+        breakdown: '[14]',
+        timestamp: '2024-06-01T12:00:00.000Z',
+      });
+
+      const result = await handleRollDice({ formula: '1d20' }, client);
+      const text = getText(result);
+
+      expect(text).toContain('Dice Roll Result');
+      expect(text).toContain('**Formula:** 1d20');
+      expect(text).toContain('**Total:** 14');
+      expect(text).toContain('**Breakdown:** [14]');
+      expect(text).toContain('**Timestamp:** 2024-06-01T12:00:00.000Z');
+      // No reason supplied — that line should be absent
+      expect(text).not.toContain('**Reason:**');
+      expect(client.rollDice).toHaveBeenCalledWith('1d20', undefined);
+    });
+
+    it('includes the reason line when supplied', async () => {
+      const client = mockFoundryClient({
+        formula: '3d6+4',
+        total: 17,
+        breakdown: '[5,4,4] + 4',
+        reason: 'Damage roll',
+        timestamp: '2024-06-01T12:00:00.000Z',
+      });
+
+      const result = await handleRollDice({ formula: '3d6+4', reason: 'Damage roll' }, client);
+      const text = getText(result);
+
+      expect(text).toContain('**Formula:** 3d6+4');
+      expect(text).toContain('**Total:** 17');
+      expect(text).toContain('**Reason:** Damage roll');
+      expect(client.rollDice).toHaveBeenCalledWith('3d6+4', 'Damage roll');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('propagates errors from the FoundryClient as an McpError', async () => {
+      const client = {
+        rollDice: vi.fn(async () => {
+          throw new Error('Invalid formula');
+        }),
+      } as unknown as FoundryClient;
+
+      await expect(handleRollDice({ formula: 'bogus' }, client)).rejects.toThrow();
+    });
+  });
+});

--- a/src/tools/handlers/__tests__/generation.test.ts
+++ b/src/tools/handlers/__tests__/generation.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @fileoverview Unit tests for content generation handlers
+ *
+ * Covers handleGenerateNPC, handleGenerateLoot, and handleLookupRule.
+ * Math.random is stubbed for determinism.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FoundryClient } from '../../../foundry/client.js';
+import {
+  handleGenerateLoot,
+  handleGenerateNPC,
+  handleLookupRule,
+} from '../generation.js';
+
+// The handlers do not call any FoundryClient methods, so an empty stub suffices.
+const stubClient = {} as unknown as FoundryClient;
+
+function getText(result: { content: Array<{ type: string; text: string }> }): string {
+  return result.content[0]?.text ?? '';
+}
+
+describe('handleGenerateNPC', () => {
+  beforeEach(() => {
+    // Math.random returns 0.5 → middle-of-array picks, deterministic ability scores
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('happy path', () => {
+    it('returns a formatted NPC with default level when no args given', async () => {
+      const result = await handleGenerateNPC({}, stubClient);
+      const text = getText(result);
+
+      expect(text).toContain('Generated NPC');
+      expect(text).toContain('**Level:** 1');
+      expect(text).toContain('**Name:**');
+      expect(text).toContain('**Race:**');
+      expect(text).toContain('**Class:**');
+      expect(text).toContain('**Hit Points:**');
+      expect(text).toContain('**STR:**');
+      expect(text).toContain('**DEX:**');
+      expect(text).toContain('**CON:**');
+      expect(text).toContain('**INT:**');
+      expect(text).toContain('**WIS:**');
+      expect(text).toContain('**CHA:**');
+      expect(text).toContain('**Background:**');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('honors caller-supplied race, class, and level', async () => {
+      const result = await handleGenerateNPC(
+        { level: 5, race: 'Dwarf', class: 'Wizard' },
+        stubClient,
+      );
+      const text = getText(result);
+
+      expect(text).toContain('**Level:** 5');
+      expect(text).toContain('**Race:** Dwarf');
+      expect(text).toContain('**Class:** Wizard');
+    });
+  });
+});
+
+describe('handleGenerateLoot', () => {
+  beforeEach(() => {
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('happy path', () => {
+    it('returns formatted loot with default CR=1 and treasureType=individual', async () => {
+      const result = await handleGenerateLoot({}, stubClient);
+      const text = getText(result);
+
+      expect(text).toContain('Generated Loot');
+      expect(text).toContain('**Challenge Rating:** 1');
+      expect(text).toContain('**Treasure Type:** individual');
+      expect(text).toContain('**Currency:**');
+      expect(text).toContain('**Items:**');
+      expect(text).toContain('**Total Estimated Value:**');
+      expect(text).toContain('gp');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('honors caller-supplied challengeRating and treasureType', async () => {
+      const result = await handleGenerateLoot(
+        { challengeRating: 10, treasureType: 'hoard' },
+        stubClient,
+      );
+      const text = getText(result);
+
+      expect(text).toContain('**Challenge Rating:** 10');
+      expect(text).toContain('**Treasure Type:** hoard');
+    });
+  });
+});
+
+describe('handleLookupRule', () => {
+  describe('happy path', () => {
+    it('returns formatted rule with default system D&D 5e', async () => {
+      const result = await handleLookupRule({ query: 'Grapple' }, stubClient);
+      const text = getText(result);
+
+      expect(text).toContain('Rule Lookup: Grapple');
+      expect(text).toContain('**System:** D&D 5e');
+      expect(text).toContain('**Rule:** Grapple Rule');
+      expect(text).toContain('**Description:**');
+      expect(text).toContain('**Mechanics:**');
+      expect(text).toContain('**Source:** D&D 5e Core Rulebook');
+    });
+
+    it('honors caller-supplied system', async () => {
+      const result = await handleLookupRule(
+        { query: 'Sanity', system: 'Call of Cthulhu' },
+        stubClient,
+      );
+      const text = getText(result);
+
+      expect(text).toContain('**System:** Call of Cthulhu');
+      expect(text).toContain('**Source:** Call of Cthulhu Core Rulebook');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('throws McpError when query is empty string', async () => {
+      await expect(
+        handleLookupRule({ query: '' } as { query: string }, stubClient),
+      ).rejects.toThrow(/Query is required/);
+    });
+
+    it('throws McpError when query is not a string', async () => {
+      await expect(
+        // Intentionally passing wrong type to exercise runtime guard
+        handleLookupRule({ query: 42 } as unknown as { query: string }, stubClient),
+      ).rejects.toThrow(/Query is required/);
+    });
+  });
+});

--- a/src/tools/handlers/__tests__/items.test.ts
+++ b/src/tools/handlers/__tests__/items.test.ts
@@ -1,0 +1,146 @@
+/**
+ * @fileoverview Unit tests for items handler — search_items formatting and filters
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { FoundryClient } from '../../../foundry/client.js';
+import { handleSearchItems } from '../items.js';
+
+interface MockItem {
+  _id: string;
+  name: string;
+  type: string;
+  rarity?: string;
+  price?: { value: number; denomination: string };
+}
+
+interface MockSearchParams {
+  query: string;
+  type?: string;
+  rarity?: string;
+  limit: number;
+}
+
+function mockFoundryClient(
+  result: { items: MockItem[]; total: number; page: number; limit: number },
+): { client: FoundryClient; calls: { params: MockSearchParams[] } } {
+  const calls = { params: [] as MockSearchParams[] };
+  const client = {
+    searchItems: vi.fn(async (params: MockSearchParams) => {
+      calls.params.push(params);
+      return result;
+    }),
+  } as unknown as FoundryClient;
+  return { client, calls };
+}
+
+function getText(result: Awaited<ReturnType<typeof handleSearchItems>>): string {
+  return (result as { content: Array<{ type: string; text: string }> }).content[0]?.text ?? '';
+}
+
+describe('handleSearchItems', () => {
+  describe('happy path', () => {
+    it('formats item results with name, type, rarity, and price', async () => {
+      const { client, calls } = mockFoundryClient({
+        items: [
+          {
+            _id: 'item-1',
+            name: 'Longsword',
+            type: 'weapon',
+            rarity: 'Common',
+            price: { value: 15, denomination: 'gp' },
+          },
+          {
+            _id: 'item-2',
+            name: 'Potion of Healing',
+            type: 'consumable',
+            rarity: 'Common',
+            price: { value: 50, denomination: 'gp' },
+          },
+        ],
+        total: 2,
+        page: 1,
+        limit: 10,
+      });
+
+      const result = await handleSearchItems(
+        { query: 'sword', type: 'weapon', rarity: 'Common' },
+        client,
+      );
+      const text = getText(result);
+
+      expect(text).toContain('Item Search Results');
+      expect(text).toContain('**Query:** sword');
+      expect(text).toContain('**Type Filter:** weapon');
+      expect(text).toContain('**Rarity Filter:** Common');
+      expect(text).toContain('**Results:** 2/2 total');
+      expect(text).toContain('**Longsword** (weapon) - Common - 15 gp');
+      expect(text).toContain('**Potion of Healing** (consumable) - Common - 50 gp');
+      expect(text).toContain('**Page:** 1 | **Limit:** 10');
+
+      // Verify filters were forwarded
+      expect(calls.params).toHaveLength(1);
+      expect(calls.params[0]).toMatchObject({
+        query: 'sword',
+        type: 'weapon',
+        rarity: 'Common',
+        limit: 10,
+      });
+    });
+
+    it('defaults query/type/rarity labels when none supplied and uses default limit 10', async () => {
+      const { client, calls } = mockFoundryClient({
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 10,
+      });
+
+      const result = await handleSearchItems({}, client);
+      const text = getText(result);
+
+      expect(text).toContain('**Query:** All items');
+      expect(text).toContain('**Type Filter:** All types');
+      expect(text).toContain('**Rarity Filter:** All rarities');
+      // Filters should not be passed when undefined
+      expect(calls.params[0]).toEqual({ query: '', limit: 10 });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('renders "No items found" placeholder for empty result set', async () => {
+      const { client } = mockFoundryClient({
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 10,
+      });
+
+      const result = await handleSearchItems({ query: 'xyzzy' }, client);
+      const text = getText(result);
+
+      expect(text).toContain('No items found matching the criteria.');
+    });
+
+    it('falls back to "Common" rarity and "Unknown price" when item fields are missing', async () => {
+      const { client } = mockFoundryClient({
+        items: [
+          {
+            _id: 'item-3',
+            name: 'Mystery Box',
+            type: 'misc',
+            // no rarity, no price
+          },
+        ],
+        total: 1,
+        page: 1,
+        limit: 10,
+      });
+
+      const result = await handleSearchItems({ query: 'box' }, client);
+      const text = getText(result);
+
+      expect(text).toContain('**Mystery Box** (misc) - Common - Unknown price');
+    });
+  });
+});

--- a/src/tools/handlers/__tests__/journals.test.ts
+++ b/src/tools/handlers/__tests__/journals.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @fileoverview Unit tests for journals handlers — search_journals and get_journal
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { FoundryClient } from '../../../foundry/client.js';
+import { handleGetJournal, handleSearchJournals } from '../journals.js';
+
+interface MockJournal {
+  _id: string;
+  name: string;
+  pages?: Array<{
+    _id: string;
+    name: string;
+    type: string;
+    text?: { content: string; format: number };
+  }>;
+}
+
+function getText(result: { content: Array<{ type: string; text: string }> }): string {
+  return result.content[0]?.text ?? '';
+}
+
+function makeJournal(id: string, name: string, pageCount: number): MockJournal {
+  return {
+    _id: id,
+    name,
+    pages: Array.from({ length: pageCount }, (_, i) => ({
+      _id: `${id}-page-${i}`,
+      name: `Page ${i + 1}`,
+      type: 'text',
+      text: { content: `<p>Page ${i + 1} content for ${name}.</p>`, format: 1 },
+    })),
+  };
+}
+
+describe('handleSearchJournals', () => {
+  describe('happy path', () => {
+    it('formats matching journals with page count and ID', async () => {
+      const journals: MockJournal[] = [
+        makeJournal('jrnl-1', 'Adventure Log', 5),
+        makeJournal('jrnl-2', 'Lore Compendium', 1),
+        makeJournal('jrnl-3', 'Empty Journal', 0),
+      ];
+      const client = {
+        searchJournals: vi.fn((_q: string) => journals),
+      } as unknown as FoundryClient;
+
+      const result = await handleSearchJournals({ query: 'adventure' }, client);
+      const text = getText(result);
+
+      expect(text).toContain('Journal Search');
+      expect(text).toContain('"adventure"');
+      expect(text).toContain('(3 results)');
+      expect(text).toContain('**Adventure Log** (5 pages)');
+      expect(text).toContain('**Lore Compendium** (1 page)');
+      expect(text).toContain('**Empty Journal** (0 pages)');
+      expect(text).toContain('ID: jrnl-1');
+      expect(text).toContain('ID: jrnl-2');
+      expect(client.searchJournals).toHaveBeenCalledWith('adventure');
+    });
+
+    it('honors a caller-supplied limit', async () => {
+      const journals: MockJournal[] = Array.from({ length: 25 }, (_, i) =>
+        makeJournal(`jrnl-${i}`, `Journal ${i}`, 1),
+      );
+      const client = {
+        searchJournals: vi.fn(() => journals),
+      } as unknown as FoundryClient;
+
+      const result = await handleSearchJournals({ query: 'j', limit: 5 }, client);
+      const text = getText(result);
+
+      // Total count still reflects the full result set
+      expect(text).toContain('(25 results)');
+      // But only the first 5 entries are listed
+      expect(text).toContain('**Journal 0**');
+      expect(text).toContain('**Journal 4**');
+      expect(text).not.toContain('**Journal 5**');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns "No journals found" placeholder when search returns empty', async () => {
+      const client = {
+        searchJournals: vi.fn(() => []),
+      } as unknown as FoundryClient;
+
+      const result = await handleSearchJournals({ query: 'xyzzy' }, client);
+      const text = getText(result);
+
+      expect(text).toContain('No journals found matching "xyzzy".');
+    });
+  });
+});
+
+describe('handleGetJournal', () => {
+  describe('happy path', () => {
+    it('returns journal with HTML-stripped page content', async () => {
+      const journal: MockJournal = {
+        _id: 'jrnl-1',
+        name: 'Test Journal',
+        pages: [
+          {
+            _id: 'p-1',
+            name: 'Introduction',
+            type: 'text',
+            text: { content: '<p>Hello <b>world</b>.</p>', format: 1 },
+          },
+        ],
+      };
+      const client = {
+        getJournal: vi.fn((_id: string) => journal),
+      } as unknown as FoundryClient;
+
+      const result = await handleGetJournal({ journalId: 'jrnl-1' }, client);
+      const text = getText(result);
+
+      expect(text).toContain('**Journal: Test Journal**');
+      expect(text).toContain('ID: jrnl-1');
+      expect(text).toContain('### Introduction');
+      expect(text).toContain('Hello world.');
+      // HTML tags should have been stripped
+      expect(text).not.toContain('<p>');
+      expect(text).not.toContain('<b>');
+      expect(client.getJournal).toHaveBeenCalledWith('jrnl-1');
+    });
+
+    it('falls back to "No pages." when journal has no pages', async () => {
+      const journal: MockJournal = { _id: 'jrnl-2', name: 'Empty', pages: [] };
+      const client = {
+        getJournal: vi.fn(() => journal),
+      } as unknown as FoundryClient;
+
+      const result = await handleGetJournal({ journalId: 'jrnl-2' }, client);
+      const text = getText(result);
+
+      expect(text).toContain('**Journal: Empty**');
+      expect(text).toContain('No pages.');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('throws McpError when journal not found', async () => {
+      const client = {
+        getJournal: vi.fn(() => undefined),
+      } as unknown as FoundryClient;
+
+      await expect(handleGetJournal({ journalId: 'missing' }, client)).rejects.toThrow(
+        /Journal not found: missing/,
+      );
+    });
+
+    it('truncates page content longer than 500 chars with ellipsis', async () => {
+      const longText = 'a'.repeat(600);
+      const journal: MockJournal = {
+        _id: 'jrnl-3',
+        name: 'Long',
+        pages: [
+          {
+            _id: 'p-1',
+            name: 'Big Page',
+            type: 'text',
+            text: { content: longText, format: 1 },
+          },
+        ],
+      };
+      const client = {
+        getJournal: vi.fn(() => journal),
+      } as unknown as FoundryClient;
+
+      const result = await handleGetJournal({ journalId: 'jrnl-3' }, client);
+      const text = getText(result);
+
+      expect(text).toContain('### Big Page');
+      expect(text).toContain('...');
+      // The 500-char slice should be present but the full 600-char string should not
+      expect(text).not.toContain('a'.repeat(600));
+    });
+  });
+});

--- a/src/tools/handlers/__tests__/search_logs.test.ts
+++ b/src/tools/handlers/__tests__/search_logs.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @fileoverview Unit tests for diagnostics handler — handleSearchLogs
+ *
+ * Lives in a separate test file from diagnostics.test.ts to keep
+ * the existing get_recent_logs coverage untouched.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { DiagnosticsClient } from '../../../diagnostics/client.js';
+import { handleSearchLogs } from '../diagnostics.js';
+
+function getText(result: { content: Array<{ type: string; text: string }> }): string {
+  return result.content[0]?.text ?? '';
+}
+
+function mockClient(logs: unknown): DiagnosticsClient {
+  return {
+    searchLogs: vi.fn(async (_params: { pattern: string }) => logs),
+  } as unknown as DiagnosticsClient;
+}
+
+describe('handleSearchLogs', () => {
+  describe('happy path', () => {
+    it('formats matching log entries with timestamp, level, and message', async () => {
+      const logs = [
+        {
+          timestamp: '2024-06-01T12:00:00.000Z',
+          level: 'error',
+          message: 'database connection failed',
+        },
+        {
+          timestamp: '2024-06-01T12:00:01.000Z',
+          level: 'warn',
+          message: 'retry attempt 1',
+        },
+      ];
+      const client = mockClient(logs);
+
+      const result = await handleSearchLogs({ query: 'database', level: 'error' }, client);
+      const text = getText(result);
+
+      expect(text).toContain('Log Search Results');
+      expect(text).toContain('**Query:** "database"');
+      expect(text).toContain('**Level Filter:** error');
+      expect(text).toContain('**Results:** 2');
+      expect(text).toContain('**ERROR** database connection failed');
+      expect(text).toContain('**WARN** retry attempt 1');
+      expect(client.searchLogs).toHaveBeenCalledWith({ pattern: 'database' });
+    });
+
+    it('renders default "All levels" filter label when level not supplied', async () => {
+      const client = mockClient([
+        { timestamp: '2024-06-01T12:00:00.000Z', level: 'info', message: 'hello' },
+      ]);
+
+      const result = await handleSearchLogs({ query: 'hello' }, client);
+      const text = getText(result);
+
+      expect(text).toContain('**Level Filter:** All levels');
+      expect(text).toContain('**INFO** hello');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns zero results and empty body when client returns empty array', async () => {
+      const client = mockClient([]);
+      const result = await handleSearchLogs({ query: 'xyzzy' }, client);
+      const text = getText(result);
+
+      expect(text).toContain('**Results:** 0');
+      expect(text).toContain('No matching log entries found.');
+    });
+
+    it('throws McpError when query is empty string', async () => {
+      const client = mockClient([]);
+      await expect(
+        handleSearchLogs({ query: '' } as { query: string }, client),
+      ).rejects.toThrow(/Query is required/);
+    });
+
+    it('throws McpError when query is not a string', async () => {
+      const client = mockClient([]);
+      await expect(
+        handleSearchLogs({ query: 42 } as unknown as { query: string }, client),
+      ).rejects.toThrow(/Query is required/);
+    });
+
+    it('falls back to defaults when log entries lack timestamp/level/message', async () => {
+      // Use stringifiable values for the fall-through `String(log)` branch
+      const logs = [{}, { message: 'partial' }];
+      const client = mockClient(logs);
+
+      const result = await handleSearchLogs({ query: 'anything' }, client);
+      const text = getText(result);
+
+      // Entries with no `level` should default to INFO; entries without timestamp get a fresh one
+      expect(text).toContain('**INFO**');
+      expect(text).toContain('**Results:** 2');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 5 new test files in \`src/tools/handlers/__tests__/\`:
  - \`dice.test.ts\` — 3 tests (roll_dice happy paths + error propagation)
  - \`generation.test.ts\` — 8 tests (generate_npc, generate_loot, lookup_rule with stubbed RNG)
  - \`items.test.ts\` — 4 tests (search_items formatting + filter passthrough + missing-field fallbacks)
  - \`journals.test.ts\` — 7 tests (search_journals + get_journal incl. HTML stripping and 500-char truncation)
  - \`search_logs.test.ts\` — 6 tests (search_logs in diagnostics.ts; separate file to avoid colliding with the existing \`diagnostics.test.ts\`)
- 5 commits, one per file.
- Total **28 new tests**, all green.

Closes #134 (combined with the actors/combat/world PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)