### PR TITLE
test(e2e): add Playwright baseline smoke spec

### DIFF
--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Baseline smoke test for the Playwright E2E harness.
+ *
+ * Purpose: prove that the Playwright config loads, browsers launch, and a
+ * spec can run end-to-end. This is intentionally tiny — it is the foothold
+ * for future E2E coverage, not coverage itself.
+ *
+ * The test skips gracefully when FoundryVTT is not reachable so it remains
+ * green in CI environments without the live VTT instance / credentials.
+ *
+ * Tracked by issue #137.
+ */
+
+const FOUNDRY_URL = process.env.FOUNDRY_URL || 'http://localhost:30000';
+
+/**
+ * Probe FoundryVTT availability using Node's built-in fetch. Done inside
+ * the test (not at module scope) so the probe error is attributed to this
+ * spec rather than a load-time failure if the network call throws.
+ */
+async function isFoundryReachable(): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 3000);
+    try {
+      const res = await fetch(FOUNDRY_URL, { signal: controller.signal });
+      return res.status < 500;
+    } finally {
+      clearTimeout(timer);
+    }
+  } catch {
+    return false;
+  }
+}
+
+test('playwright harness loads and can reach a page', async ({ page }) => {
+  const reachable = await isFoundryReachable();
+  test.skip(
+    !reachable,
+    `FoundryVTT not reachable at ${FOUNDRY_URL} — baseline smoke test skipped (set FOUNDRY_URL or start the container to exercise it).`,
+  );
+
+  // Minimal interaction: navigate and assert we received a non-error
+  // response and a string title. Deliberately does not assert
+  // FoundryVTT-specific markup so it survives version changes.
+  const response = await page.goto(FOUNDRY_URL);
+  expect(response, 'page.goto returned a response').not.toBeNull();
+  expect(response!.status(), 'response status is not a server error').toBeLessThan(500);
+
+  const title = await page.title();
+  expect(typeof title).toBe('string');
+});


### PR DESCRIPTION
## Summary

- New \`tests/e2e/smoke.spec.ts\` (54 lines, 1 test).
- Pre-flight \`fetch\` probe with 3s timeout — calls \`test.skip()\` inline if FOUNDRY_URL is unreachable.
- Asserts \`page.goto(FOUNDRY_URL)\` returns non-null with status < 500, and \`page.title()\` returns a string. Deliberately UI-agnostic so it doesn't drift with FVTT changes.

## Decision context

Per #137: the repo had Playwright config + dependencies but zero exercising tests. Direction selected: keep the harness, add a baseline. This PR is the baseline.

## Skip behavior

- With \`FOUNDRY_URL\` set to a reachable instance: test runs the navigation (verified locally — passes in ~600ms).
- Without \`FOUNDRY_URL\` or with no live instance: test reports as skipped, suite passes. Safe for CI without secrets.

> One-time setup cost users will hit: \`npx playwright install chromium\` (~92 MiB browser download). Not added to CI here — that's a separate decision when E2E coverage actually grows.

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)