### PR TITLE
feat(tools): actor item CRUD, attribute mutation & compendium search (#142, #143, #144)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,12 @@ FOUNDRY_PASSWORD=your_password
 # to enable 5 server monitoring tools (logs, health, diagnostics)
 # FOUNDRY_API_KEY=your_api_key_here
 
+# Write operations (game-state mutation) — disabled by default.
+# When true, tools like update_actor_attributes / create_actor_item perform
+# mutations over the authenticated Socket.IO session (modifyDocument protocol).
+# Requires the connected user to have GM/owner permission in FoundryVTT.
+# FOUNDRY_WRITE_ENABLED=true
+
 # MCP Server Configuration
 MCP_SERVER_NAME=foundryvtt-mcp
 MCP_SERVER_VERSION=0.1.0

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -57,6 +57,7 @@ const ConfigSchema = z.object({
     timeout: z.number().default(10000),
     retryAttempts: z.number().default(3),
     retryDelay: z.number().default(1000),
+    writeEnabled: z.boolean().default(false),
   }),
 
   cache: z.object({
@@ -111,6 +112,10 @@ function loadConfig(): Config {
       retryDelay: process.env.FOUNDRY_RETRY_DELAY
         ? parseInt(process.env.FOUNDRY_RETRY_DELAY, 10)
         : undefined,
+      writeEnabled:
+        process.env.FOUNDRY_WRITE_ENABLED !== undefined
+          ? process.env.FOUNDRY_WRITE_ENABLED === 'true'
+          : undefined,
     },
 
     cache: {

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -11,9 +11,13 @@ import { z } from 'zod';
 import { logger } from '../utils/logger.js';
 import { authenticateFoundry } from './auth.js';
 import type {
+  ActorAttributeUpdateResult,
+  ActorItemCreateSource,
   ActorSearchResult,
+  CompendiumSearchResult,
   DiceRoll,
   FoundryActor,
+  FoundryItem,
   FoundryScene,
   FoundryWorld,
   ItemSearchResult,
@@ -60,6 +64,17 @@ export interface FoundryClientConfig {
   retryAttempts?: number;
   retryDelay?: number;
   socketPath?: string;
+  /** Opt-in gate for game-state mutations (FOUNDRY_WRITE_ENABLED). Default false. */
+  writeEnabled?: boolean;
+}
+
+/** Minimal shape of FoundryVTT's `modifyDocument` Socket.IO acknowledgement. */
+interface DocumentSocketResponse {
+  /** Created/updated data objects, or deleted ids, on success. */
+  result?: unknown[];
+  /** Present when the server rejects the operation. */
+  error?: { message?: string } | null;
+  userId?: string;
 }
 
 export interface SearchActorsParams {
@@ -74,6 +89,27 @@ export interface SearchItemsParams {
   rarity?: string;
   limit?: number;
 }
+
+export interface CompendiumSearchParams {
+  query?: string;
+  packType?: string;
+  itemType?: string;
+  spellLevel?: number;
+  source?: string;
+  compendiumId?: string;
+  limit?: number;
+  /** Opaque pagination cursor from a prior result's `nextCursor`. */
+  cursor?: string;
+}
+
+/**
+ * Shallow attribute patch for {@link FoundryClient.updateActorAttribute} (#143).
+ *
+ * Keys are dot-paths into the actor's `system` object (e.g.
+ * `attributes.hp.value`, `currency.gp`, `spells.spell1.value`,
+ * `attributes.exhaustion`). Values are the scalar to set at that path.
+ */
+export type AttributePatch = Record<string, number | string | boolean>;
 
 export class FoundryClient {
   private http: AxiosInstance;
@@ -357,6 +393,67 @@ export class FoundryClient {
     return this.worldData?.actors.find((a) => a._id === actorId);
   }
 
+  /**
+   * Patches attributes on an actor's `system` object (#143). WRITE — REST required.
+   *
+   * `patch` keys are dot-paths into `actor.system` (e.g. `attributes.hp.value`,
+   * `currency.gp`, `spells.spell1.value`, `attributes.exhaustion`). The patch is
+   * expanded into a nested object and sent as `PUT /api/actors/:actorId` with the
+   * body `{ system: <expanded patch> }` — matching FoundryVTT's own document model
+   * (`Actor#update`).
+   *
+   * Client-side validation, using the actor's current data, rejects:
+   *  - HP value exceeding `max + temp`,
+   *  - spell-slot value exceeding its `max`,
+   *  - exhaustion outside `0–10` (2024 rules) or `0–6` (2014 rules).
+   *
+   * @throws if `apiKey` is unset, the id is malformed, the actor/path is missing,
+   *   or a validation rule is violated.
+   */
+  async updateActorAttribute(
+    actorId: string,
+    patch: AttributePatch,
+  ): Promise<ActorAttributeUpdateResult> {
+    this.assertWriteable();
+    if (!FOUNDRY_ID_PATTERN.test(actorId)) {
+      throw new Error(`Invalid actorId format: ${actorId}`);
+    }
+    if (!isRecord(patch) || Object.keys(patch).length === 0) {
+      throw new Error('patch is required and must contain at least one attribute path');
+    }
+
+    // Fetch current actor data to validate paths and bounds. getActor returns
+    // the mapped actor in socket mode (no `system`), so fall back to the cached
+    // raw actor for the system document the validator needs.
+    const actor = await this.getActor(actorId);
+    const rawSystem = systemOf(actor) ?? systemOf(this.getRawActor(actorId));
+    validateAttributePatch(patch, actor, rawSystem);
+
+    // The patch keys are dot-paths into `actor.system`; prefix each with
+    // `system.` for the document update. FoundryVTT accepts dot-notation keys
+    // in update objects and merges recursively.
+    const update: Record<string, unknown> = { _id: actorId };
+    for (const [path, value] of Object.entries(patch)) {
+      update[`system.${path}`] = value;
+    }
+    const result = await this.modifyDocument('Actor', 'update', {
+      updates: [update],
+      diff: true,
+      recursive: true,
+    });
+
+    // Echo the post-update value for each patched path. Prefer the server's
+    // returned document when present; otherwise reflect the requested value.
+    const returned = isRecord(result[0]) ? (result[0] as Record<string, unknown>) : undefined;
+    const updatedAttributes: Record<string, unknown> = {};
+    for (const [path, value] of Object.entries(patch)) {
+      const fromServer = returned ? getDotPath(returned, `system.${path}`) : undefined;
+      updatedAttributes[path] = fromServer !== undefined ? fromServer : value;
+    }
+
+    return { success: true, updatedAttributes };
+  }
+
   // ==========================================================================
   // Item methods
   // ==========================================================================
@@ -414,6 +511,213 @@ export class FoundryClient {
     });
 
     return { items, total, page: 1, limit };
+  }
+
+  // ==========================================================================
+  // Compendium methods
+  // ==========================================================================
+
+  /**
+   * Searches FoundryVTT compendium packs by name and metadata.
+   *
+   * Compendium data is not present in the cached worldData snapshot, so this
+   * read requires the REST API module (FOUNDRY_API_KEY). When the key is
+   * absent it returns a graceful empty result with `restAvailable: false`
+   * rather than throwing, mirroring the no-worldData behaviour of
+   * {@link searchItems}/{@link searchActors}; the handler surfaces a note
+   * explaining why no results were returned.
+   */
+  async searchCompendium(params: CompendiumSearchParams): Promise<CompendiumSearchResult> {
+    const limit = params.limit ?? 20;
+    const offset = decodeCursor(params.cursor);
+
+    if (this.config.apiKey) {
+      return this.executeWithRetry(async () => {
+        // Translate the opaque cursor into a wire offset for the bridge.
+        const { cursor: _cursor, ...rest } = params;
+        const response = await this.http.get('/api/compendium/search', {
+          params: { ...rest, limit, offset },
+        });
+        const data = (
+          isRecord(response.data) ? response.data : {}
+        ) as Partial<CompendiumSearchResult>;
+        const results = data.results ?? [];
+        const total = typeof data.total === 'number' ? data.total : results.length;
+        const nextOffset = offset + results.length;
+        return {
+          results,
+          total,
+          page: Math.floor(offset / limit) + 1,
+          limit,
+          restAvailable: true,
+          nextCursor: nextOffset < total ? encodeCursor(nextOffset) : null,
+        };
+      });
+    }
+    return { results: [], total: 0, page: 1, limit, restAvailable: false, nextCursor: null };
+  }
+
+  // ==========================================================================
+  // Write helpers (Socket.IO `modifyDocument` — primary transport, PRD-003)
+  // ==========================================================================
+
+  /**
+   * Guards a write operation. Writes require the `FOUNDRY_WRITE_ENABLED` opt-in
+   * and an active authenticated Socket.IO session (the primary transport).
+   * Throws a clear, actionable error otherwise.
+   */
+  private assertWriteable(): void {
+    if (!this.config.writeEnabled) {
+      throw new Error(
+        'Write operations are disabled. Set FOUNDRY_WRITE_ENABLED=true to allow game-state mutation.',
+      );
+    }
+    if (!this.socket?.connected) {
+      throw new Error(
+        'Write operations require an active Socket.IO connection to FoundryVTT (username/password mode).',
+      );
+    }
+  }
+
+  /**
+   * Emits a Socket.IO event with an acknowledgement callback, resolving the
+   * server's response and rejecting on timeout. Mirrors the ack pattern used by
+   * the `world` event in {@link connectAndLoadWorld}/{@link refreshWorldData}.
+   */
+  private emitWithAck<T>(event: string, payload: unknown): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const socket = this.socket;
+      if (!socket?.connected) {
+        reject(new Error('Socket.IO is not connected'));
+        return;
+      }
+      const timeoutMs = this.config.timeout || 10000;
+      const timeout = setTimeout(
+        () => reject(new Error(`Timeout waiting for '${event}' response (${timeoutMs}ms)`)),
+        timeoutMs,
+      );
+      socket.emit(event, payload, (response: T) => {
+        clearTimeout(timeout);
+        resolve(response);
+      });
+    });
+  }
+
+  /**
+   * Performs a FoundryVTT document mutation over Socket.IO using the core
+   * `modifyDocument` protocol. The request shape is verified against the
+   * v13.348 client source (`client/data/client-backend.mjs` `#buildRequest`,
+   * `helpers/socket-interface.mjs` `dispatch`, `common/abstract/socket.mjs`).
+   *
+   * @param type - Document name ("Actor", "Item", …)
+   * @param action - "create" | "update" | "delete"
+   * @param operation - action-specific payload: `data` (create) / `updates`
+   *   (update) / `ids` (delete), plus `parentUuid` for embedded documents.
+   * @returns the server's `result` array (created/updated data, or deleted ids)
+   */
+  private async modifyDocument(
+    type: string,
+    action: 'create' | 'update' | 'delete',
+    operation: Record<string, unknown>,
+  ): Promise<unknown[]> {
+    const request = {
+      type,
+      action,
+      operation: { broadcast: true, pack: null, modifiedTime: Date.now(), ...operation },
+    };
+    const response = await this.emitWithAck<DocumentSocketResponse>('modifyDocument', request);
+    if (response?.error) {
+      throw new Error(
+        `FoundryVTT rejected ${action} ${type}: ${response.error.message || 'unknown error'}`,
+      );
+    }
+    return Array.isArray(response?.result) ? response.result : [];
+  }
+
+  // ==========================================================================
+  // Item mutation methods (WRITE — Socket.IO modifyDocument)
+  // ==========================================================================
+
+  /**
+   * Creates a new item on an actor via the `modifyDocument` socket protocol.
+   *
+   * Inline sources are created directly. Compendium sources are NOT yet
+   * supported over Socket.IO — copying a pack entry needs a compendium read
+   * that `modifyDocument` does not provide (tracked in issue #159).
+   *
+   * @param actorId - 16-char alphanumeric actor document id
+   * @param source - inline item document (compendium source throws)
+   * @returns the newly created item document
+   */
+  async createActorItem(actorId: string, source: ActorItemCreateSource): Promise<FoundryItem> {
+    this.assertWriteable();
+    if (!FOUNDRY_ID_PATTERN.test(actorId)) {
+      throw new Error(`Invalid actorId format: ${actorId}`);
+    }
+    if (source.type === 'compendium') {
+      throw new Error(
+        'Creating an item from a compendium source is not yet supported over Socket.IO; ' +
+          'provide an inline item instead. See issue #159.',
+      );
+    }
+    const result = await this.modifyDocument('Item', 'create', {
+      data: [source.item],
+      parentUuid: `Actor.${actorId}`,
+    });
+    return result[0] as FoundryItem;
+  }
+
+  /**
+   * Applies a JSON merge patch to an item owned by an actor.
+   *
+   * The `patch` is merged into the item's `system` data (recursively, so nested
+   * paths like the D&D 5e v4+ `activities.{id}.consumption.targets` are
+   * preserved). Performed via the `modifyDocument` socket protocol.
+   *
+   * @param actorId - 16-char alphanumeric actor document id
+   * @param itemId - 16-char alphanumeric item document id
+   * @param patch - shallow/nested JSON merge patch applied to `item.system`
+   * @returns the updated item document
+   */
+  async updateActorItem(
+    actorId: string,
+    itemId: string,
+    patch: Record<string, unknown>,
+  ): Promise<FoundryItem> {
+    this.assertWriteable();
+    if (!FOUNDRY_ID_PATTERN.test(actorId)) {
+      throw new Error(`Invalid actorId format: ${actorId}`);
+    }
+    if (!FOUNDRY_ID_PATTERN.test(itemId)) {
+      throw new Error(`Invalid itemId format: ${itemId}`);
+    }
+    const result = await this.modifyDocument('Item', 'update', {
+      updates: [{ _id: itemId, system: patch }],
+      parentUuid: `Actor.${actorId}`,
+      diff: true,
+      recursive: true,
+    });
+    return result[0] as FoundryItem;
+  }
+
+  /**
+   * Deletes an item owned by an actor via the `modifyDocument` socket protocol.
+   *
+   * @param actorId - 16-char alphanumeric actor document id
+   * @param itemId - 16-char alphanumeric item document id
+   */
+  async deleteActorItem(actorId: string, itemId: string): Promise<void> {
+    this.assertWriteable();
+    if (!FOUNDRY_ID_PATTERN.test(actorId)) {
+      throw new Error(`Invalid actorId format: ${actorId}`);
+    }
+    if (!FOUNDRY_ID_PATTERN.test(itemId)) {
+      throw new Error(`Invalid itemId format: ${itemId}`);
+    }
+    await this.modifyDocument('Item', 'delete', {
+      ids: [itemId],
+      parentUuid: `Actor.${actorId}`,
+    });
   }
 
   // ==========================================================================
@@ -865,6 +1169,36 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
+/**
+ * Returns the `system` object of an actor-like document, accepting either the
+ * raw REST/world document (`{ ..., system }`) or a cached {@link WorldActor}.
+ * Returns undefined when no system object is present (e.g. the mapped
+ * {@link FoundryActor} produced by the socket world-cache path).
+ */
+function systemOf(obj: unknown): Record<string, unknown> | undefined {
+  if (isRecord(obj) && isRecord(obj.system)) {
+    return obj.system;
+  }
+  return undefined;
+}
+
+/**
+ * Compendium pagination cursors are opaque base64-encoded result offsets.
+ * `encodeCursor` turns an offset into a cursor; `decodeCursor` reads it back,
+ * returning 0 when the cursor is absent or malformed.
+ */
+function encodeCursor(offset: number): string {
+  return Buffer.from(String(offset), 'utf8').toString('base64');
+}
+
+function decodeCursor(cursor: string | undefined): number {
+  if (!cursor) {
+    return 0;
+  }
+  const decoded = Number.parseInt(Buffer.from(cursor, 'base64').toString('utf8'), 10);
+  return Number.isFinite(decoded) && decoded >= 0 ? decoded : 0;
+}
+
 function extractNested(obj: Record<string, unknown>, ...keys: string[]): unknown {
   let current: unknown = obj;
   for (const key of keys) {
@@ -883,4 +1217,90 @@ function extractNested(obj: Record<string, unknown>, ...keys: string[]): unknown
 function extractString(obj: Record<string, unknown>, ...keys: string[]): string | null {
   const val = extractNested(obj, ...keys);
   return typeof val === 'string' ? val : null;
+}
+
+// ============================================================================
+// Attribute-patch helpers (#143)
+// ============================================================================
+
+/**
+ * Reads a dot-path out of a nested Record tree, returning undefined if any
+ * segment is missing.
+ */
+function getDotPath(obj: Record<string, unknown>, path: string): unknown {
+  return extractNested(obj, ...path.split('.'));
+}
+
+/**
+ * Reads the actor's game-system id from raw world data, when available.
+ * Used to pick the exhaustion clamp (2024 dnd5e: 0–10; 2014: 0–6).
+ */
+function exhaustionMax(sys: Record<string, unknown> | undefined): number {
+  // dnd5e 2024 rules cap exhaustion at 10; the 2014 rules cap it at 6.
+  // Without an explicit rules-version signal, default to the wider 2024 range
+  // so legitimate 2024 values are not rejected; the 2014 cap is applied when
+  // the actor's system data exposes a `rules: "2014"`-style marker.
+  if (isRecord(sys)) {
+    const source = isRecord(sys._source) ? sys._source : undefined;
+    const rules =
+      extractString(sys, 'rules') ||
+      (source ? extractString(source, 'rules') : null) ||
+      extractString(sys, 'attributes', 'exhaustion', 'rules');
+    if (rules === '2014' || rules === 'legacy') {
+      return 6;
+    }
+  }
+  return 10;
+}
+
+/**
+ * Validates an attribute patch against the actor's current data, throwing a
+ * clear error on the first violation. Only checks rules for which the needed
+ * limit (max HP, slot max, exhaustion bound) is available.
+ */
+function validateAttributePatch(
+  patch: AttributePatch,
+  actor: FoundryActor,
+  rawSystem: Record<string, unknown> | undefined,
+): void {
+  // Prefer the raw `system` document for bounds: in REST mode getActor returns
+  // the raw document (HP at system.attributes.hp.{value,max,temp}); the mapped
+  // FoundryActor.hp is only populated on the socket world-cache path.
+  const rawHp = rawSystem ? extractNested(rawSystem, 'attributes', 'hp') : undefined;
+  const hp = isRecord(rawHp) ? rawHp : undefined;
+
+  for (const [path, value] of Object.entries(patch)) {
+    // HP value cannot exceed max + temp.
+    if (path === 'attributes.hp.value' && typeof value === 'number') {
+      const patchedTemp = patch['attributes.hp.temp'];
+      const currentTemp = typeof hp?.temp === 'number' ? hp.temp : (actor.hp?.temp ?? 0);
+      const temp = typeof patchedTemp === 'number' ? patchedTemp : currentTemp;
+      const max = typeof hp?.max === 'number' ? hp.max : actor.hp?.max;
+      if (typeof max === 'number' && value > max + temp) {
+        throw new Error(
+          `Invalid HP value ${value}: exceeds max + temp (${max} + ${temp} = ${max + temp})`,
+        );
+      }
+    }
+
+    // Spell-slot value cannot exceed its max.
+    const slotMatch = /^spells\.(spell\w+|pact)\.value$/.exec(path);
+    const slotKey = slotMatch?.[1];
+    if (slotKey && typeof value === 'number' && rawSystem) {
+      const slotMax = extractNested(rawSystem, 'spells', slotKey, 'max');
+      if (typeof slotMax === 'number' && value > slotMax) {
+        throw new Error(
+          `Invalid spell slot value ${value} for ${slotKey}: exceeds max (${slotMax})`,
+        );
+      }
+    }
+
+    // Exhaustion clamped 0–10 (2024) or 0–6 (2014).
+    if (path === 'attributes.exhaustion' && typeof value === 'number') {
+      const max = exhaustionMax(rawSystem);
+      if (value < 0 || value > max) {
+        throw new Error(`Invalid exhaustion ${value}: must be between 0 and ${max}`);
+      }
+    }
+  }
 }

--- a/src/foundry/types.ts
+++ b/src/foundry/types.ts
@@ -552,6 +552,87 @@ export interface ItemSearchResult {
   limit: number;
 }
 
+/**
+ * A single compendium search result entry.
+ *
+ * Carries enough metadata to disambiguate near-identical entries across
+ * packs and rule revisions (e.g. Divine Smite PHB-2014 vs PHB-2024 via
+ * `system.source.rules`). `compendiumId` scopes the entry to its pack and
+ * `itemId` identifies the entry within that pack.
+ */
+export interface CompendiumSearchEntry {
+  compendiumId: string;
+  itemId: string;
+  name: string;
+  type: string;
+  img?: string;
+  system?: {
+    level?: number;
+    school?: string;
+    source?: {
+      rules?: string;
+      custom?: string;
+    };
+  };
+}
+
+/**
+ * Result envelope for a compendium search.
+ *
+ * `restAvailable` signals whether the REST API module (FOUNDRY_API_KEY) was
+ * present. When false, `results` is empty and the handler surfaces a note
+ * explaining that compendium search requires REST mode.
+ *
+ * `nextCursor` carries the opaque pagination cursor for the following page
+ * (an offset, base64-encoded); it is `null` when no further results exist.
+ */
+export interface CompendiumSearchResult {
+  results: CompendiumSearchEntry[];
+  total: number;
+  page: number;
+  limit: number;
+  restAvailable: boolean;
+  nextCursor: string | null;
+}
+
+/**
+ * Source for creating an item on an actor.
+ *
+ * Either references a compendium entry to copy (the compendium pack id plus the
+ * item id within that pack — pairs with the compendium search tool) or supplies
+ * an inline item document to create directly.
+ */
+export type ActorItemCreateSource =
+  | {
+      type: 'compendium';
+      compendiumId: string;
+      itemId: string;
+    }
+  | {
+      type: 'inline';
+      item: Partial<FoundryItem>;
+    };
+
+/**
+ * Result structure for an actor attribute update (#143).
+ *
+ * Returned by `FoundryClient.updateActorAttribute`. The `updatedAttributes`
+ * map echoes back the post-update value for every patched dot-path so callers
+ * can confirm what changed.
+ *
+ * @example
+ * ```typescript
+ * const result: ActorAttributeUpdateResult = {
+ *   success: true,
+ *   updatedAttributes: { 'attributes.hp.value': 30, 'currency.gp': 12 },
+ * };
+ * ```
+ */
+export interface ActorAttributeUpdateResult {
+  success: boolean;
+  updatedAttributes: Record<string, unknown>;
+}
+
 // API Response types
 /**
  * Generic API response structure for FoundryVTT REST API

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,7 @@ class FoundryMCPServer {
       timeout: config.foundry.timeout,
       retryAttempts: config.foundry.retryAttempts,
       retryDelay: config.foundry.retryDelay,
+      writeEnabled: config.foundry.writeEnabled,
     };
     if (config.foundry.apiKey) {
       clientConfig.apiKey = config.foundry.apiKey;

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -72,6 +72,43 @@ export const actorTools = [
 ];
 
 /**
+ * Actor attribute mutation tool definitions (#143)
+ *
+ * WRITE operations — require FOUNDRY_WRITE_ENABLED=true and an active
+ * Socket.IO connection (mutations use the core `modifyDocument` protocol).
+ */
+export const actorMutationTools = [
+  {
+    name: 'update_actor_attributes',
+    description:
+      "Update attributes on an actor's system data. The patch keys are dot-paths into actor.system " +
+      '(e.g. "attributes.hp.value", "attributes.hp.temp", "currency.gp", "resources.primary.value", ' +
+      '"spells.spell1.value", "attributes.exhaustion"). Returns the post-update value for every patched ' +
+      'path. Validates HP <= max + temp, spell slots <= max, and exhaustion within 0-10 (2024) or 0-6 (2014). ' +
+      'Requires FOUNDRY_WRITE_ENABLED=true and an active Socket.IO connection.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        actorId: {
+          type: 'string',
+          description: 'The ID of the actor to update',
+        },
+        patch: {
+          type: 'object',
+          description:
+            'Map of dot-path → value, where each dot-path addresses a field under actor.system ' +
+            '(e.g. {"attributes.hp.value": 30, "currency.gp": 12}). Values must be number, string, or boolean.',
+          additionalProperties: {
+            type: ['number', 'string', 'boolean'],
+          },
+        },
+      },
+      required: ['actorId', 'patch'],
+    },
+  },
+];
+
+/**
  * Item management tool definitions
  */
 export const itemTools = [
@@ -99,6 +136,156 @@ export const itemTools = [
           default: 10,
         },
       },
+    },
+  },
+];
+
+/**
+ * Compendium search tool definitions (#144)
+ */
+export const compendiumTools = [
+  {
+    name: 'search_compendium',
+    description:
+      'Search FoundryVTT compendium packs by name and metadata. Searches all enabled compendiums by default; the compendiumId filter scopes to one pack. Requires the REST API module (FOUNDRY_API_KEY).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'Search query for compendium entry names',
+        },
+        filters: {
+          type: 'object',
+          description: 'Optional metadata filters to narrow the search',
+          properties: {
+            compendiumId: {
+              type: 'string',
+              description: 'Scope the search to a single compendium pack',
+            },
+            packType: {
+              type: 'string',
+              description: 'Pack document type (Item, Actor, JournalEntry, Macro)',
+            },
+            itemType: {
+              type: 'string',
+              description: 'Item type filter (spell, weapon, feat, etc.)',
+            },
+            spellLevel: {
+              type: 'number',
+              description: 'Spell level filter',
+            },
+            source: {
+              type: 'string',
+              description: 'Source/rules filter (e.g. a sourcebook abbreviation)',
+            },
+          },
+        },
+        limit: {
+          type: 'number',
+          description: 'Maximum number of results per page',
+          default: 20,
+        },
+        cursor: {
+          type: 'string',
+          description:
+            'Opaque pagination cursor from a prior result\'s "Next page" cursor; omit for the first page',
+        },
+      },
+      required: ['query'],
+    },
+  },
+];
+
+/**
+ * Actor item mutation tool definitions (WRITE — require FOUNDRY_WRITE_ENABLED
+ * and an active Socket.IO connection; mutations use `modifyDocument`)
+ *
+ * The canonical mutation target is the D&D 5e v4+ activity schema. Item
+ * `system` patches honour JSON-merge-patch semantics on nested paths.
+ */
+export const itemMutationTools = [
+  {
+    name: 'create_actor_item',
+    description:
+      'Create an item on an actor from an inline item document (requires FOUNDRY_WRITE_ENABLED + active Socket.IO connection). Compendium-source create is not yet supported over Socket.IO (see issue #159). Canonical target: D&D 5e v4+ activity schema.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        actorId: {
+          type: 'string',
+          description: 'The ID of the actor to add the item to',
+        },
+        source: {
+          type: 'object',
+          description:
+            'Item source: { type: "compendium", compendiumId, itemId } to copy a compendium entry, or { type: "inline", item: { type, name, system } } to create directly',
+          properties: {
+            type: {
+              type: 'string',
+              enum: ['compendium', 'inline'],
+              description: 'Source kind',
+            },
+            compendiumId: {
+              type: 'string',
+              description: 'Compendium pack id (compendium source)',
+            },
+            itemId: {
+              type: 'string',
+              description: 'Item id within the compendium pack (compendium source)',
+            },
+            item: {
+              type: 'object',
+              description: 'Inline item document with type, name, and system (inline source)',
+            },
+          },
+          required: ['type'],
+        },
+      },
+      required: ['actorId', 'source'],
+    },
+  },
+  {
+    name: 'update_actor_item',
+    description:
+      "Apply a JSON merge patch to an item's system data on an actor (requires FOUNDRY_WRITE_ENABLED + active Socket.IO connection). Supports nested paths such as activities.{id}.consumption.targets. Canonical target: D&D 5e v4+ activity schema.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        actorId: {
+          type: 'string',
+          description: 'The ID of the actor that owns the item',
+        },
+        itemId: {
+          type: 'string',
+          description: 'The ID of the item to update',
+        },
+        patch: {
+          type: 'object',
+          description:
+            'JSON merge patch applied to item.system; nested paths supported (e.g. activities.{id}.consumption.targets)',
+        },
+      },
+      required: ['actorId', 'itemId', 'patch'],
+    },
+  },
+  {
+    name: 'delete_actor_item',
+    description:
+      'Delete an item owned by an actor (requires FOUNDRY_WRITE_ENABLED + active Socket.IO connection). Canonical target: D&D 5e v4+ activity schema.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        actorId: {
+          type: 'string',
+          description: 'The ID of the actor that owns the item',
+        },
+        itemId: {
+          type: 'string',
+          description: 'The ID of the item to delete',
+        },
+      },
+      required: ['actorId', 'itemId'],
     },
   },
 ];
@@ -411,7 +598,10 @@ export function getAllTools() {
   return [
     ...diceTools,
     ...actorTools,
+    ...actorMutationTools,
     ...itemTools,
+    ...compendiumTools,
+    ...itemMutationTools,
     ...sceneTools,
     ...combatTools,
     ...chatTools,

--- a/src/tools/handlers/__tests__/actor-mutations.test.ts
+++ b/src/tools/handlers/__tests__/actor-mutations.test.ts
@@ -1,0 +1,312 @@
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it, vi } from 'vitest';
+import { FoundryClient } from '../../../foundry/client.js';
+import type { ActorAttributeUpdateResult } from '../../../foundry/types.js';
+import { handleUpdateActorAttribute } from '../actor-mutations.js';
+
+const VALID_ID = 'aaaaaaaaaaaaaaaa'; // 16 alphanumeric chars
+
+describe('Actor mutation handlers', () => {
+  const createMockClient = (
+    impl?: (
+      actorId: string,
+      patch: Record<string, number | string | boolean>,
+    ) => ActorAttributeUpdateResult | Promise<ActorAttributeUpdateResult>,
+  ): FoundryClient => {
+    return {
+      updateActorAttribute: vi.fn(
+        impl ??
+          ((_actorId: string, patch: Record<string, number | string | boolean>) => ({
+            success: true,
+            updatedAttributes: { ...patch },
+          })),
+      ),
+    } as unknown as FoundryClient;
+  };
+
+  describe('handleUpdateActorAttribute', () => {
+    it('round-trips HP value and echoes the updated path', async () => {
+      const mockClient = createMockClient();
+      const result = await handleUpdateActorAttribute(
+        { actorId: VALID_ID, patch: { 'attributes.hp.value': 30 } },
+        mockClient,
+      );
+
+      const text = result.content[0].text;
+      expect(result.content[0].type).toBe('text');
+      expect(text).toContain('Actor Attributes Updated');
+      expect(text).toContain('**attributes.hp.value** → 30');
+      expect(text).toContain('Success');
+    });
+
+    it('round-trips a spell-slot value', async () => {
+      const mockClient = createMockClient();
+      const result = await handleUpdateActorAttribute(
+        { actorId: VALID_ID, patch: { 'spells.spell1.value': 2 } },
+        mockClient,
+      );
+
+      expect(result.content[0].text).toContain('**spells.spell1.value** → 2');
+    });
+
+    it('round-trips a resource/currency value', async () => {
+      const mockClient = createMockClient();
+      const result = await handleUpdateActorAttribute(
+        { actorId: VALID_ID, patch: { 'currency.gp': 12, 'resources.primary.value': 3 } },
+        mockClient,
+      );
+
+      const text = result.content[0].text;
+      expect(text).toContain('**currency.gp** → 12');
+      expect(text).toContain('**resources.primary.value** → 3');
+    });
+
+    it('propagates a not-found error from the client', async () => {
+      const mockClient = createMockClient(() => {
+        throw new Error(`Actor not found: ${VALID_ID}`);
+      });
+
+      await expect(
+        handleUpdateActorAttribute(
+          { actorId: VALID_ID, patch: { 'attributes.hp.value': 5 } },
+          mockClient,
+        ),
+      ).rejects.toThrow(/Failed to update actor attributes/);
+    });
+
+    it('propagates the write-disabled guard error', async () => {
+      const mockClient = createMockClient(() => {
+        throw new Error(
+          'Write operations are disabled. Set FOUNDRY_WRITE_ENABLED=true to allow game-state mutation.',
+        );
+      });
+
+      await expect(
+        handleUpdateActorAttribute(
+          { actorId: VALID_ID, patch: { 'attributes.hp.value': 5 } },
+          mockClient,
+        ),
+      ).rejects.toThrow(/FOUNDRY_WRITE_ENABLED/);
+    });
+
+    it('rejects a missing actorId before reaching the client', async () => {
+      const mockClient = createMockClient();
+      await expect(
+        handleUpdateActorAttribute(
+          { actorId: '', patch: { 'attributes.hp.value': 5 } },
+          mockClient,
+        ),
+      ).rejects.toThrow(McpError);
+      expect(mockClient.updateActorAttribute).not.toHaveBeenCalled();
+    });
+
+    it('rejects an empty patch before reaching the client', async () => {
+      const mockClient = createMockClient();
+      await expect(
+        handleUpdateActorAttribute({ actorId: VALID_ID, patch: {} }, mockClient),
+      ).rejects.toThrow(McpError);
+      expect(mockClient.updateActorAttribute).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-object patch before reaching the client', async () => {
+      const mockClient = createMockClient();
+      await expect(
+        handleUpdateActorAttribute(
+          {
+            actorId: VALID_ID,
+            patch: 'nope' as unknown as Record<string, number>,
+          },
+          mockClient,
+        ),
+      ).rejects.toThrow(McpError);
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // Client-level validation (exercises the real updateActorAttribute logic).
+  // --------------------------------------------------------------------------
+  describe('FoundryClient.updateActorAttribute validation', () => {
+    type SocketEmitMock = (
+      event: string,
+      payload: unknown,
+      cb: (response: unknown) => void,
+    ) => void;
+
+    const buildClient = (opts: {
+      writeEnabled?: boolean;
+      connected?: boolean;
+      actor?: Record<string, unknown>;
+      rawActor?: Record<string, unknown>;
+    }) => {
+      const client = new FoundryClient({
+        baseUrl: 'http://localhost:30000',
+        writeEnabled: opts.writeEnabled ?? true,
+      });
+      if (opts.actor) {
+        vi.spyOn(client, 'getActor').mockResolvedValue(
+          opts.actor as unknown as Awaited<ReturnType<FoundryClient['getActor']>>,
+        );
+      }
+      vi.spyOn(client, 'getRawActor').mockReturnValue(
+        opts.rawActor as unknown as ReturnType<FoundryClient['getRawActor']>,
+      );
+      // Install a mock Socket.IO socket. The modifyDocument ack echoes the
+      // update object back as the server's `result`, mirroring FoundryVTT.
+      const emit = vi.fn(((_event, payload, cb) => {
+        const op = (payload as { operation?: { updates?: Array<Record<string, unknown>> } })
+          .operation;
+        cb({ result: op?.updates ? [op.updates[0]] : [] });
+      }) as SocketEmitMock);
+      if (opts.connected !== false) {
+        (client as unknown as { socket: { connected: boolean; emit: SocketEmitMock } }).socket = {
+          connected: true,
+          emit,
+        };
+      }
+      return client;
+    };
+
+    it('rejects writes when FOUNDRY_WRITE_ENABLED is false', async () => {
+      const client = buildClient({ writeEnabled: false });
+      await expect(
+        client.updateActorAttribute(VALID_ID, { 'attributes.hp.value': 5 }),
+      ).rejects.toThrow(/FOUNDRY_WRITE_ENABLED/);
+    });
+
+    it('rejects writes when the Socket.IO connection is not active', async () => {
+      const client = buildClient({ writeEnabled: true, connected: false });
+      await expect(
+        client.updateActorAttribute(VALID_ID, { 'attributes.hp.value': 5 }),
+      ).rejects.toThrow(/Socket\.IO connection/);
+    });
+
+    it('rejects a malformed actor id', async () => {
+      const client = buildClient({});
+      await expect(
+        client.updateActorAttribute('short', { 'attributes.hp.value': 5 }),
+      ).rejects.toThrow(/Invalid actorId/);
+    });
+
+    // In REST mode getActor returns the raw FoundryVTT document, so HP bounds
+    // live at system.attributes.hp — NOT the mapped top-level `hp`. These cases
+    // assert validation reads from the raw system shape (no socket cache).
+    it('rejects HP above max + temp (REST raw-document shape)', async () => {
+      const client = buildClient({
+        actor: {
+          _id: VALID_ID,
+          name: 'Hero',
+          type: 'character',
+          system: { attributes: { hp: { value: 10, max: 20, temp: 0 } } },
+        },
+      });
+      await expect(
+        client.updateActorAttribute(VALID_ID, { 'attributes.hp.value': 25 }),
+      ).rejects.toThrow(/exceeds max \+ temp/);
+    });
+
+    it('allows HP up to max + temp (REST raw-document shape)', async () => {
+      const client = buildClient({
+        actor: {
+          _id: VALID_ID,
+          name: 'Hero',
+          type: 'character',
+          system: { attributes: { hp: { value: 10, max: 20, temp: 5 } } },
+        },
+      });
+      const result = await client.updateActorAttribute(VALID_ID, { 'attributes.hp.value': 25 });
+      expect(result.success).toBe(true);
+      expect(result.updatedAttributes['attributes.hp.value']).toBe(25);
+    });
+
+    // Socket mode: getActor returns the mapped actor (top-level `hp`) and the
+    // raw system comes from the world cache. Validation must still enforce the
+    // cap by falling back to the mapped HP bounds.
+    it('rejects HP above max + temp (socket mapped-actor fallback)', async () => {
+      const client = buildClient({
+        actor: {
+          _id: VALID_ID,
+          name: 'Hero',
+          type: 'character',
+          hp: { value: 10, max: 20, temp: 0 },
+        },
+        rawActor: { _id: VALID_ID, name: 'Hero', type: 'character', system: {} },
+      });
+      await expect(
+        client.updateActorAttribute(VALID_ID, { 'attributes.hp.value': 25 }),
+      ).rejects.toThrow(/exceeds max \+ temp/);
+    });
+
+    it('rejects a spell slot above its max', async () => {
+      const client = buildClient({
+        actor: { _id: VALID_ID, name: 'Mage', type: 'character', hp: { value: 8, max: 8 } },
+        rawActor: {
+          _id: VALID_ID,
+          name: 'Mage',
+          type: 'character',
+          system: { spells: { spell1: { value: 0, max: 3 } } },
+        },
+      });
+      await expect(
+        client.updateActorAttribute(VALID_ID, { 'spells.spell1.value': 4 }),
+      ).rejects.toThrow(/exceeds max/);
+    });
+
+    it('rejects exhaustion out of the 0-10 range', async () => {
+      const client = buildClient({
+        actor: { _id: VALID_ID, name: 'Hero', type: 'character', hp: { value: 8, max: 8 } },
+        rawActor: { _id: VALID_ID, name: 'Hero', type: 'character', system: {} },
+      });
+      await expect(
+        client.updateActorAttribute(VALID_ID, { 'attributes.exhaustion': 11 }),
+      ).rejects.toThrow(/between 0 and 10/);
+      await expect(
+        client.updateActorAttribute(VALID_ID, { 'attributes.exhaustion': -1 }),
+      ).rejects.toThrow(/between 0 and 10/);
+    });
+
+    it('applies the 2014 exhaustion cap of 6 when the actor uses legacy rules', async () => {
+      const client = buildClient({
+        actor: { _id: VALID_ID, name: 'Hero', type: 'character', hp: { value: 8, max: 8 } },
+        rawActor: {
+          _id: VALID_ID,
+          name: 'Hero',
+          type: 'character',
+          system: { rules: '2014' },
+        },
+      });
+      await expect(
+        client.updateActorAttribute(VALID_ID, { 'attributes.exhaustion': 7 }),
+      ).rejects.toThrow(/between 0 and 6/);
+    });
+
+    it('emits a system-prefixed modifyDocument update and returns updated values', async () => {
+      const client = buildClient({
+        actor: { _id: VALID_ID, name: 'Hero', type: 'character', hp: { value: 8, max: 20 } },
+        rawActor: { _id: VALID_ID, name: 'Hero', type: 'character', system: {} },
+      });
+      const result = await client.updateActorAttribute(VALID_ID, {
+        'attributes.hp.value': 15,
+        'currency.gp': 12,
+      });
+      expect(result.success).toBe(true);
+      expect(result.updatedAttributes['attributes.hp.value']).toBe(15);
+      expect(result.updatedAttributes['currency.gp']).toBe(12);
+
+      // Verify the modifyDocument request: dot-paths prefixed with `system.`,
+      // wrapped in an Actor update operation over the socket.
+      const emitMock = (client as unknown as { socket: { emit: ReturnType<typeof vi.fn> } }).socket
+        .emit;
+      const [event, body] = emitMock.mock.calls[0];
+      expect(event).toBe('modifyDocument');
+      expect(body).toMatchObject({
+        type: 'Actor',
+        action: 'update',
+        operation: {
+          updates: [{ _id: VALID_ID, 'system.attributes.hp.value': 15, 'system.currency.gp': 12 }],
+          broadcast: true,
+          pack: null,
+        },
+      });
+    });
+  });
+});

--- a/src/tools/handlers/__tests__/compendium.test.ts
+++ b/src/tools/handlers/__tests__/compendium.test.ts
@@ -1,0 +1,131 @@
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it, vi } from 'vitest';
+import type { FoundryClient } from '../../../foundry/client.js';
+import type { CompendiumSearchResult } from '../../../foundry/types.js';
+import { handleSearchCompendium } from '../compendium.js';
+
+describe('Compendium handlers', () => {
+  const divineSmite2014: CompendiumSearchResult = {
+    results: [
+      {
+        compendiumId: 'dnd5e.spells',
+        itemId: 'abcdef0123456789',
+        name: 'Divine Smite',
+        type: 'spell',
+        img: 'icons/svg/aura.svg',
+        system: { level: 1, school: 'evo', source: { rules: '2014' } },
+      },
+    ],
+    total: 1,
+    page: 1,
+    limit: 20,
+    restAvailable: true,
+    nextCursor: null,
+  };
+
+  const createMockClient = (result: CompendiumSearchResult = divineSmite2014): FoundryClient => {
+    return {
+      searchCompendium: vi.fn(() => result),
+    } as unknown as FoundryClient;
+  };
+
+  describe('handleSearchCompendium', () => {
+    it('returns compendium entries with disambiguating metadata', async () => {
+      const mockClient = createMockClient();
+      const result = await handleSearchCompendium({ query: 'Divine Smite', limit: 20 }, mockClient);
+
+      const text = result.content[0].text;
+      expect(result.content[0].type).toBe('text');
+      expect(text).toContain('Compendium Search Results');
+      expect(text).toContain('Divine Smite');
+      // compendiumId and itemId must be present to disambiguate
+      expect(text).toContain('dnd5e.spells');
+      expect(text).toContain('abcdef0123456789');
+      // rule revision distinguishes PHB-2014 vs PHB-2024
+      expect(text).toContain('rules: 2014');
+    });
+
+    it('uses default limit of 20 when not specified', async () => {
+      const mockClient = createMockClient();
+      const result = await handleSearchCompendium({ query: 'Fireball' }, mockClient);
+
+      expect(result.content[0].text).toContain('**Limit:** 20');
+    });
+
+    it('passes filters through to the client', async () => {
+      const mockClient = createMockClient();
+      await handleSearchCompendium(
+        { query: 'Divine Smite', filters: { compendiumId: 'dnd5e.spells', spellLevel: 1 } },
+        mockClient,
+      );
+
+      expect(mockClient.searchCompendium).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: 'Divine Smite',
+          compendiumId: 'dnd5e.spells',
+          spellLevel: 1,
+        }),
+      );
+    });
+
+    it('surfaces a REST-required note on graceful empty', async () => {
+      const mockClient = createMockClient({
+        results: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        restAvailable: false,
+        nextCursor: null,
+      });
+      const result = await handleSearchCompendium({ query: 'Divine Smite' }, mockClient);
+
+      const text = result.content[0].text;
+      expect(text).toContain('No compendium entries found');
+      expect(text).toContain('requires FOUNDRY_API_KEY');
+    });
+
+    it('surfaces the next-page cursor when more results remain', async () => {
+      const mockClient = createMockClient({
+        ...divineSmite2014,
+        total: 40,
+        nextCursor: 'MjA=', // base64 of offset 20
+      });
+      const result = await handleSearchCompendium({ query: 'Divine Smite', limit: 20 }, mockClient);
+
+      const text = result.content[0].text;
+      expect(text).toContain('Next page');
+      expect(text).toContain('MjA=');
+    });
+
+    it('passes a pagination cursor through to the client', async () => {
+      const mockClient = createMockClient();
+      await handleSearchCompendium({ query: 'Divine Smite', cursor: 'MjA=' }, mockClient);
+
+      expect(mockClient.searchCompendium).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'Divine Smite', cursor: 'MjA=' }),
+      );
+    });
+
+    it('rejects with InvalidParams on missing query', async () => {
+      const mockClient = createMockClient();
+      await expect(handleSearchCompendium({ query: '' }, mockClient)).rejects.toThrow(McpError);
+    });
+
+    it('rejects with InvalidParams on non-string query', async () => {
+      const mockClient = createMockClient();
+      await expect(
+        handleSearchCompendium({ query: 123 as unknown as string }, mockClient),
+      ).rejects.toThrow(McpError);
+    });
+
+    it('propagates client errors through withToolError', async () => {
+      const mockClient = {
+        searchCompendium: vi.fn(() => {
+          throw new Error('Compendium pack not found');
+        }),
+      } as unknown as FoundryClient;
+
+      await expect(handleSearchCompendium({ query: 'Divine Smite' }, mockClient)).rejects.toThrow();
+    });
+  });
+});

--- a/src/tools/handlers/__tests__/item-mutations.test.ts
+++ b/src/tools/handlers/__tests__/item-mutations.test.ts
@@ -1,0 +1,407 @@
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it, vi } from 'vitest';
+import { FoundryClient } from '../../../foundry/client.js';
+import type { FoundryItem } from '../../../foundry/types.js';
+import {
+  handleCreateActorItem,
+  handleDeleteActorItem,
+  handleUpdateActorItem,
+} from '../item-mutations.js';
+
+const VALID_ACTOR_ID = 'abcdefABCDEF0123';
+const VALID_ITEM_ID = '0123456789abcdef';
+
+const sampleItem: FoundryItem = {
+  _id: VALID_ITEM_ID,
+  name: 'Longsword',
+  type: 'weapon',
+};
+
+const featWithActivity: FoundryItem = {
+  _id: VALID_ITEM_ID,
+  name: 'Action Surge',
+  type: 'feat',
+};
+
+const createMockClient = (overrides: Partial<FoundryClient> = {}): FoundryClient => {
+  return {
+    createActorItem: vi.fn(async () => sampleItem),
+    updateActorItem: vi.fn(async () => sampleItem),
+    deleteActorItem: vi.fn(async () => undefined),
+    ...overrides,
+  } as unknown as FoundryClient;
+};
+
+describe('item mutation handlers', () => {
+  describe('handleCreateActorItem', () => {
+    it('creates an item from an inline source', async () => {
+      const mockClient = createMockClient();
+      const result = await handleCreateActorItem(
+        {
+          actorId: VALID_ACTOR_ID,
+          source: { type: 'inline', item: { type: 'weapon', name: 'Longsword' } },
+        },
+        mockClient,
+      );
+
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Item Created');
+      expect(result.content[0].text).toContain('Longsword');
+      expect(result.content[0].text).toContain('D&D 5e v4+ activity schema');
+      expect(mockClient.createActorItem).toHaveBeenCalledWith(VALID_ACTOR_ID, {
+        type: 'inline',
+        item: { type: 'weapon', name: 'Longsword' },
+      });
+    });
+
+    it('creates an item from a compendium source (passes ids through)', async () => {
+      const mockClient = createMockClient();
+      const result = await handleCreateActorItem(
+        {
+          actorId: VALID_ACTOR_ID,
+          source: { type: 'compendium', compendiumId: 'dnd5e.items', itemId: VALID_ITEM_ID },
+        },
+        mockClient,
+      );
+
+      expect(result.content[0].text).toContain('compendium dnd5e.items');
+      expect(mockClient.createActorItem).toHaveBeenCalledWith(VALID_ACTOR_ID, {
+        type: 'compendium',
+        compendiumId: 'dnd5e.items',
+        itemId: VALID_ITEM_ID,
+      });
+    });
+
+    it('rejects an empty actorId with InvalidParams', async () => {
+      const mockClient = createMockClient();
+      await expect(
+        handleCreateActorItem(
+          { actorId: '', source: { type: 'inline', item: { name: 'x', type: 'weapon' } } },
+          mockClient,
+        ),
+      ).rejects.toThrow(McpError);
+    });
+
+    it('rejects a missing source with InvalidParams', async () => {
+      const mockClient = createMockClient();
+      await expect(
+        handleCreateActorItem(
+          {
+            actorId: VALID_ACTOR_ID,
+            source: undefined as unknown as { type: 'inline'; item: Partial<FoundryItem> },
+          },
+          mockClient,
+        ),
+      ).rejects.toThrow(McpError);
+    });
+
+    it('rejects an unknown source type with InvalidParams', async () => {
+      const mockClient = createMockClient();
+      await expect(
+        handleCreateActorItem(
+          {
+            actorId: VALID_ACTOR_ID,
+            source: { type: 'bogus' } as unknown as { type: 'inline'; item: Partial<FoundryItem> },
+          },
+          mockClient,
+        ),
+      ).rejects.toThrow(McpError);
+    });
+
+    it('propagates a not-found error from the client', async () => {
+      const mockClient = createMockClient({
+        createActorItem: vi.fn(async () => {
+          throw new Error('Actor not found: abcdefABCDEF0123');
+        }),
+      });
+      await expect(
+        handleCreateActorItem(
+          {
+            actorId: VALID_ACTOR_ID,
+            source: { type: 'inline', item: { name: 'x', type: 'weapon' } },
+          },
+          mockClient,
+        ),
+      ).rejects.toThrow(McpError);
+    });
+
+    it('surfaces the write-disabled guard error', async () => {
+      const mockClient = createMockClient({
+        createActorItem: vi.fn(async () => {
+          throw new Error(
+            'Write operations are disabled. Set FOUNDRY_WRITE_ENABLED=true to allow game-state mutation.',
+          );
+        }),
+      });
+      await expect(
+        handleCreateActorItem(
+          {
+            actorId: VALID_ACTOR_ID,
+            source: { type: 'inline', item: { name: 'x', type: 'weapon' } },
+          },
+          mockClient,
+        ),
+      ).rejects.toThrow('FOUNDRY_WRITE_ENABLED');
+    });
+  });
+
+  describe('handleUpdateActorItem', () => {
+    it('updates an item with a system patch', async () => {
+      const mockClient = createMockClient();
+      const result = await handleUpdateActorItem(
+        { actorId: VALID_ACTOR_ID, itemId: VALID_ITEM_ID, patch: { equipped: true } },
+        mockClient,
+      );
+
+      expect(result.content[0].text).toContain('Item Updated');
+      expect(result.content[0].text).toContain('equipped');
+      expect(mockClient.updateActorItem).toHaveBeenCalledWith(VALID_ACTOR_ID, VALID_ITEM_ID, {
+        equipped: true,
+      });
+    });
+
+    it('round-trips adding an activity to an existing feat (nested merge patch)', async () => {
+      const mockClient = createMockClient({
+        updateActorItem: vi.fn(async () => featWithActivity),
+      });
+      const patch = {
+        activities: {
+          dnd5eactivity01: {
+            consumption: { targets: [{ type: 'itemUses', value: '1' }] },
+          },
+        },
+      };
+      const result = await handleUpdateActorItem(
+        { actorId: VALID_ACTOR_ID, itemId: VALID_ITEM_ID, patch },
+        mockClient,
+      );
+
+      expect(result.content[0].text).toContain('Action Surge');
+      expect(result.content[0].text).toContain('activities');
+      expect(mockClient.updateActorItem).toHaveBeenCalledWith(VALID_ACTOR_ID, VALID_ITEM_ID, patch);
+    });
+
+    it('rejects an empty itemId with InvalidParams', async () => {
+      const mockClient = createMockClient();
+      await expect(
+        handleUpdateActorItem(
+          { actorId: VALID_ACTOR_ID, itemId: '', patch: { equipped: true } },
+          mockClient,
+        ),
+      ).rejects.toThrow(McpError);
+    });
+
+    it('rejects a non-object patch with InvalidParams', async () => {
+      const mockClient = createMockClient();
+      await expect(
+        handleUpdateActorItem(
+          {
+            actorId: VALID_ACTOR_ID,
+            itemId: VALID_ITEM_ID,
+            patch: null as unknown as Record<string, unknown>,
+          },
+          mockClient,
+        ),
+      ).rejects.toThrow(McpError);
+    });
+
+    it('propagates a not-found error from the client', async () => {
+      const mockClient = createMockClient({
+        updateActorItem: vi.fn(async () => {
+          throw new Error('Item not found: 0123456789abcdef');
+        }),
+      });
+      await expect(
+        handleUpdateActorItem(
+          { actorId: VALID_ACTOR_ID, itemId: VALID_ITEM_ID, patch: { equipped: true } },
+          mockClient,
+        ),
+      ).rejects.toThrow(McpError);
+    });
+
+    it('surfaces the write-disabled guard error', async () => {
+      const mockClient = createMockClient({
+        updateActorItem: vi.fn(async () => {
+          throw new Error(
+            'Write operations are disabled. Set FOUNDRY_WRITE_ENABLED=true to allow game-state mutation.',
+          );
+        }),
+      });
+      await expect(
+        handleUpdateActorItem(
+          { actorId: VALID_ACTOR_ID, itemId: VALID_ITEM_ID, patch: { equipped: true } },
+          mockClient,
+        ),
+      ).rejects.toThrow('FOUNDRY_WRITE_ENABLED');
+    });
+  });
+
+  describe('handleDeleteActorItem', () => {
+    it('deletes an item', async () => {
+      const mockClient = createMockClient();
+      const result = await handleDeleteActorItem(
+        { actorId: VALID_ACTOR_ID, itemId: VALID_ITEM_ID },
+        mockClient,
+      );
+
+      expect(result.content[0].text).toContain('Item Deleted');
+      expect(result.content[0].text).toContain(VALID_ITEM_ID);
+      expect(mockClient.deleteActorItem).toHaveBeenCalledWith(VALID_ACTOR_ID, VALID_ITEM_ID);
+    });
+
+    it('rejects an empty actorId with InvalidParams', async () => {
+      const mockClient = createMockClient();
+      await expect(
+        handleDeleteActorItem({ actorId: '', itemId: VALID_ITEM_ID }, mockClient),
+      ).rejects.toThrow(McpError);
+    });
+
+    it('rejects an empty itemId with InvalidParams', async () => {
+      const mockClient = createMockClient();
+      await expect(
+        handleDeleteActorItem({ actorId: VALID_ACTOR_ID, itemId: '' }, mockClient),
+      ).rejects.toThrow(McpError);
+    });
+
+    it('propagates a not-found error from the client', async () => {
+      const mockClient = createMockClient({
+        deleteActorItem: vi.fn(async () => {
+          throw new Error('Item not found: 0123456789abcdef');
+        }),
+      });
+      await expect(
+        handleDeleteActorItem({ actorId: VALID_ACTOR_ID, itemId: VALID_ITEM_ID }, mockClient),
+      ).rejects.toThrow(McpError);
+    });
+
+    it('surfaces the write-disabled guard error', async () => {
+      const mockClient = createMockClient({
+        deleteActorItem: vi.fn(async () => {
+          throw new Error(
+            'Write operations are disabled. Set FOUNDRY_WRITE_ENABLED=true to allow game-state mutation.',
+          );
+        }),
+      });
+      await expect(
+        handleDeleteActorItem({ actorId: VALID_ACTOR_ID, itemId: VALID_ITEM_ID }, mockClient),
+      ).rejects.toThrow('FOUNDRY_WRITE_ENABLED');
+    });
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Client-level: exercises the real createActorItem/updateActorItem/
+// deleteActorItem over a mocked Socket.IO socket (modifyDocument protocol).
+// ----------------------------------------------------------------------------
+describe('FoundryClient item mutations (modifyDocument)', () => {
+  type SocketEmitMock = (event: string, payload: unknown, cb: (response: unknown) => void) => void;
+
+  const buildClient = (opts: { writeEnabled?: boolean; connected?: boolean } = {}) => {
+    const client = new FoundryClient({
+      baseUrl: 'http://localhost:30000',
+      writeEnabled: opts.writeEnabled ?? true,
+    });
+    // The ack echoes the first created/updated document (or empty for delete).
+    const emit = vi.fn(((_event, payload, cb) => {
+      const op = (
+        payload as {
+          operation?: { data?: unknown[]; updates?: unknown[] };
+        }
+      ).operation;
+      const echoed = op?.data?.[0] ?? op?.updates?.[0];
+      cb({ result: echoed ? [echoed] : [] });
+    }) as SocketEmitMock);
+    if (opts.connected !== false) {
+      (client as unknown as { socket: { connected: boolean; emit: SocketEmitMock } }).socket = {
+        connected: true,
+        emit,
+      };
+    }
+    return client;
+  };
+
+  const lastRequest = (client: FoundryClient) => {
+    const emitMock = (client as unknown as { socket: { emit: ReturnType<typeof vi.fn> } }).socket
+      .emit;
+    return emitMock.mock.calls[0];
+  };
+
+  it('creates an inline item as an embedded Item modifyDocument request', async () => {
+    const client = buildClient();
+    await client.createActorItem(VALID_ACTOR_ID, {
+      type: 'inline',
+      item: { name: 'Divine Smite', type: 'feat' },
+    });
+    const [event, body] = lastRequest(client);
+    expect(event).toBe('modifyDocument');
+    expect(body).toMatchObject({
+      type: 'Item',
+      action: 'create',
+      operation: {
+        data: [{ name: 'Divine Smite', type: 'feat' }],
+        parentUuid: `Actor.${VALID_ACTOR_ID}`,
+        broadcast: true,
+        pack: null,
+      },
+    });
+  });
+
+  it('rejects a compendium-source create over Socket.IO', async () => {
+    const client = buildClient();
+    await expect(
+      client.createActorItem(VALID_ACTOR_ID, {
+        type: 'compendium',
+        compendiumId: 'dnd5e.spells',
+        itemId: VALID_ITEM_ID,
+      }),
+    ).rejects.toThrow(/compendium source is not yet supported/);
+  });
+
+  it('updates an item with a nested system merge patch', async () => {
+    const client = buildClient();
+    const patch = { activities: { abc: { type: 'damage' } } };
+    await client.updateActorItem(VALID_ACTOR_ID, VALID_ITEM_ID, patch);
+    const [, body] = lastRequest(client);
+    expect(body).toMatchObject({
+      type: 'Item',
+      action: 'update',
+      operation: {
+        updates: [{ _id: VALID_ITEM_ID, system: patch }],
+        parentUuid: `Actor.${VALID_ACTOR_ID}`,
+        recursive: true,
+      },
+    });
+  });
+
+  it('deletes an item by id with parentUuid', async () => {
+    const client = buildClient();
+    await client.deleteActorItem(VALID_ACTOR_ID, VALID_ITEM_ID);
+    const [, body] = lastRequest(client);
+    expect(body).toMatchObject({
+      type: 'Item',
+      action: 'delete',
+      operation: { ids: [VALID_ITEM_ID], parentUuid: `Actor.${VALID_ACTOR_ID}` },
+    });
+  });
+
+  it('rejects writes when FOUNDRY_WRITE_ENABLED is false', async () => {
+    const client = buildClient({ writeEnabled: false });
+    await expect(client.deleteActorItem(VALID_ACTOR_ID, VALID_ITEM_ID)).rejects.toThrow(
+      /FOUNDRY_WRITE_ENABLED/,
+    );
+  });
+
+  it('rejects writes when the socket is not connected', async () => {
+    const client = buildClient({ connected: false });
+    await expect(client.deleteActorItem(VALID_ACTOR_ID, VALID_ITEM_ID)).rejects.toThrow(
+      /Socket\.IO connection/,
+    );
+  });
+
+  it('rejects a malformed itemId before emitting', async () => {
+    const client = buildClient();
+    await expect(client.updateActorItem(VALID_ACTOR_ID, 'short', {})).rejects.toThrow(
+      /Invalid itemId/,
+    );
+  });
+});

--- a/src/tools/handlers/actor-mutations.ts
+++ b/src/tools/handlers/actor-mutations.ts
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview Actor attribute mutation tool handlers (#143)
+ *
+ * Handles patching attributes on an actor's `system` object via dot-paths.
+ * WRITE operation — requires FOUNDRY_WRITE_ENABLED=true and an active Socket.IO
+ * connection (mutations use the core `modifyDocument` protocol).
+ */
+
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import type { AttributePatch, FoundryClient } from '../../foundry/client.js';
+import { withToolError } from './utils.js';
+
+/**
+ * Handles actor attribute update requests.
+ *
+ * `patch` keys are dot-paths into the actor's `system` object — e.g.
+ * `attributes.hp.value`, `attributes.hp.temp`, `currency.gp`,
+ * `resources.primary.value`, `spells.spell1.value`, `attributes.exhaustion`.
+ * The post-update value of every patched path is echoed back.
+ */
+export async function handleUpdateActorAttribute(
+  args: {
+    actorId: string;
+    patch: AttributePatch;
+  },
+  foundryClient: FoundryClient,
+) {
+  const { actorId, patch } = args;
+
+  if (!actorId || typeof actorId !== 'string') {
+    throw new McpError(ErrorCode.InvalidParams, 'actorId is required and must be a string');
+  }
+  if (
+    patch === null ||
+    typeof patch !== 'object' ||
+    Array.isArray(patch) ||
+    Object.keys(patch).length === 0
+  ) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      'patch is required and must be a non-empty object of dot-path attributes',
+    );
+  }
+
+  return withToolError('update actor attributes', async () => {
+    const result = await foundryClient.updateActorAttribute(actorId, patch);
+
+    const updatedList = Object.entries(result.updatedAttributes)
+      .map(([path, value]) => `- **${path}** → ${String(value)}`)
+      .join('\n');
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `⚔️ **Actor Attributes Updated**
+**Actor ID:** ${actorId}
+**Status:** ${result.success ? 'Success' : 'Failed'}
+
+**Updated attributes** (dot-paths into actor.system):
+${updatedList}`,
+        },
+      ],
+    };
+  });
+}

--- a/src/tools/handlers/compendium.ts
+++ b/src/tools/handlers/compendium.ts
@@ -1,0 +1,109 @@
+/**
+ * @fileoverview Compendium search tool handlers
+ *
+ * Read-only search across FoundryVTT compendium packs by name and metadata.
+ * Compendium data is not part of the cached worldData snapshot, so this tool
+ * requires the REST API module (FOUNDRY_API_KEY). Without it the search
+ * returns gracefully empty and the handler explains why.
+ */
+
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import type { CompendiumSearchParams, FoundryClient } from '../../foundry/client.js';
+import { withToolError } from './utils.js';
+
+interface CompendiumFilters {
+  compendiumId?: string;
+  packType?: string;
+  itemType?: string;
+  spellLevel?: number;
+  source?: string;
+}
+
+/**
+ * Handles compendium search requests.
+ *
+ * Searches across all enabled compendiums by default; the `compendiumId`
+ * filter scopes the search to a single pack. Returns enough metadata
+ * (compendiumId, itemId, type, system.source.rules) to disambiguate
+ * near-identical entries across rule revisions.
+ */
+export async function handleSearchCompendium(
+  args: {
+    query: string;
+    filters?: CompendiumFilters;
+    limit?: number;
+    cursor?: string;
+  },
+  foundryClient: FoundryClient,
+) {
+  const { query, filters, limit = 20, cursor } = args;
+
+  if (!query || typeof query !== 'string') {
+    throw new McpError(ErrorCode.InvalidParams, 'query is required and must be a string');
+  }
+
+  return withToolError('search compendium', async () => {
+    const params: CompendiumSearchParams = { query, limit };
+    if (cursor) {
+      params.cursor = cursor;
+    }
+    if (filters?.compendiumId) {
+      params.compendiumId = filters.compendiumId;
+    }
+    if (filters?.packType) {
+      params.packType = filters.packType;
+    }
+    if (filters?.itemType) {
+      params.itemType = filters.itemType;
+    }
+    if (filters?.spellLevel !== undefined) {
+      params.spellLevel = filters.spellLevel;
+    }
+    if (filters?.source) {
+      params.source = filters.source;
+    }
+
+    const result = await foundryClient.searchCompendium(params);
+
+    const entryList = result.results
+      .map((entry) => {
+        const meta: string[] = [`pack: ${entry.compendiumId}`, `id: ${entry.itemId}`];
+        if (entry.system?.level !== undefined) {
+          meta.push(`level ${entry.system.level}`);
+        }
+        if (entry.system?.school) {
+          meta.push(entry.system.school);
+        }
+        if (entry.system?.source?.rules) {
+          meta.push(`rules: ${entry.system.source.rules}`);
+        }
+        return `- **${entry.name}** (${entry.type}) — ${meta.join(', ')}`;
+      })
+      .join('\n');
+
+    const restNote =
+      result.restAvailable === false
+        ? '\n\n_Note: compendium search requires FOUNDRY_API_KEY (REST API module); returning no results._'
+        : '';
+
+    const cursorNote = result.nextCursor
+      ? `\n**Next page:** pass cursor \`${result.nextCursor}\` to retrieve more results.`
+      : '';
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `📚 **Compendium Search Results**
+**Query:** ${query}
+**Pack Filter:** ${filters?.compendiumId || 'All enabled compendiums'}
+**Results:** ${result.results.length}/${result.total} total
+
+${entryList || 'No compendium entries found matching the criteria.'}
+
+**Page:** ${result.page} | **Limit:** ${result.limit}${cursorNote}${restNote}`,
+        },
+      ],
+    };
+  });
+}

--- a/src/tools/handlers/item-mutations.ts
+++ b/src/tools/handlers/item-mutations.ts
@@ -1,0 +1,154 @@
+/**
+ * @fileoverview Actor item mutation tool handlers (create / update / delete)
+ *
+ * WRITE operations — require FOUNDRY_WRITE_ENABLED=true and an active Socket.IO
+ * connection (mutations use the core `modifyDocument` protocol). The canonical
+ * mutation target is the D&D 5e v4+ activity schema; item `system` patches
+ * honour JSON-merge-patch semantics on nested paths such as
+ * `activities.{id}.consumption.targets`.
+ */
+
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import type { FoundryClient } from '../../foundry/client.js';
+import type { ActorItemCreateSource } from '../../foundry/types.js';
+import { withToolError } from './utils.js';
+
+/**
+ * Handles creating an item on an actor from a compendium reference or an inline
+ * item document.
+ */
+export async function handleCreateActorItem(
+  args: {
+    actorId: string;
+    source: ActorItemCreateSource;
+  },
+  foundryClient: FoundryClient,
+) {
+  const { actorId, source } = args;
+
+  if (!actorId || typeof actorId !== 'string') {
+    throw new McpError(ErrorCode.InvalidParams, 'actorId is required and must be a string');
+  }
+  if (!source || typeof source !== 'object') {
+    throw new McpError(ErrorCode.InvalidParams, 'source is required and must be an object');
+  }
+  if (source.type === 'compendium') {
+    if (typeof source.compendiumId !== 'string' || typeof source.itemId !== 'string') {
+      throw new McpError(
+        ErrorCode.InvalidParams,
+        'compendium source requires compendiumId and itemId strings',
+      );
+    }
+  } else if (source.type === 'inline') {
+    if (!source.item || typeof source.item !== 'object') {
+      throw new McpError(ErrorCode.InvalidParams, 'inline source requires an item object');
+    }
+  } else {
+    throw new McpError(ErrorCode.InvalidParams, 'source.type must be "compendium" or "inline"');
+  }
+
+  return withToolError('create item', async () => {
+    const newItem = await foundryClient.createActorItem(actorId, source);
+
+    const origin =
+      source.type === 'compendium'
+        ? `compendium ${source.compendiumId} / ${source.itemId}`
+        : 'inline definition';
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `⚔️ **Item Created**
+**Actor:** ${actorId}
+**Item:** ${newItem.name} (${newItem.type})
+**Item ID:** ${newItem._id}
+**Source:** ${origin}
+
+_Canonical target: D&D 5e v4+ activity schema._`,
+        },
+      ],
+    };
+  });
+}
+
+/**
+ * Handles applying a JSON merge patch to an item's `system` data. Supports
+ * nested paths (e.g. `activities.{id}.consumption.targets`).
+ */
+export async function handleUpdateActorItem(
+  args: {
+    actorId: string;
+    itemId: string;
+    patch: Record<string, unknown>;
+  },
+  foundryClient: FoundryClient,
+) {
+  const { actorId, itemId, patch } = args;
+
+  if (!actorId || typeof actorId !== 'string') {
+    throw new McpError(ErrorCode.InvalidParams, 'actorId is required and must be a string');
+  }
+  if (!itemId || typeof itemId !== 'string') {
+    throw new McpError(ErrorCode.InvalidParams, 'itemId is required and must be a string');
+  }
+  if (!patch || typeof patch !== 'object' || Array.isArray(patch)) {
+    throw new McpError(ErrorCode.InvalidParams, 'patch is required and must be an object');
+  }
+
+  return withToolError('update item', async () => {
+    const updatedItem = await foundryClient.updateActorItem(actorId, itemId, patch);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `⚔️ **Item Updated**
+**Actor:** ${actorId}
+**Item:** ${updatedItem.name} (${updatedItem.type})
+**Item ID:** ${updatedItem._id}
+**Patched keys:** ${Object.keys(patch).join(', ') || '(none)'}
+
+_JSON merge patch applied to item.system. Canonical target: D&D 5e v4+ activity schema (e.g. activities.{id}.consumption.targets)._`,
+        },
+      ],
+    };
+  });
+}
+
+/**
+ * Handles deleting an item owned by an actor.
+ */
+export async function handleDeleteActorItem(
+  args: {
+    actorId: string;
+    itemId: string;
+  },
+  foundryClient: FoundryClient,
+) {
+  const { actorId, itemId } = args;
+
+  if (!actorId || typeof actorId !== 'string') {
+    throw new McpError(ErrorCode.InvalidParams, 'actorId is required and must be a string');
+  }
+  if (!itemId || typeof itemId !== 'string') {
+    throw new McpError(ErrorCode.InvalidParams, 'itemId is required and must be a string');
+  }
+
+  return withToolError('delete item', async () => {
+    await foundryClient.deleteActorItem(actorId, itemId);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `🗑️ **Item Deleted**
+**Actor:** ${actorId}
+**Item ID:** ${itemId}
+
+_Canonical target: D&D 5e v4+ activity schema._`,
+        },
+      ],
+    };
+  });
+}

--- a/src/tools/router.ts
+++ b/src/tools/router.ts
@@ -4,13 +4,16 @@
 
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { DiagnosticsClient } from '../diagnostics/client.js';
-import type { FoundryClient } from '../foundry/client.js';
+import type { AttributePatch, FoundryClient } from '../foundry/client.js';
+import type { ActorItemCreateSource } from '../foundry/types.js';
 import type { DiagnosticSystem } from '../utils/diagnostics.js';
 import { logger } from '../utils/logger.js';
 import type { ToolContext, ToolResult } from './base.js';
+import { handleUpdateActorAttribute } from './handlers/actor-mutations.js';
 import { handleGetActorDetails, handleSearchActors } from './handlers/actors.js';
 import { handleGetChatMessages } from './handlers/chat.js';
 import { handleGetCombatState } from './handlers/combat.js';
+import { handleSearchCompendium } from './handlers/compendium.js';
 import {
   handleDiagnoseErrors,
   handleGetHealthStatus,
@@ -21,6 +24,11 @@ import {
 // Import all tool handlers
 import { handleRollDice } from './handlers/dice.js';
 import { handleGenerateLoot, handleGenerateNPC, handleLookupRule } from './handlers/generation.js';
+import {
+  handleCreateActorItem,
+  handleDeleteActorItem,
+  handleUpdateActorItem,
+} from './handlers/item-mutations.js';
 import { handleSearchItems } from './handlers/items.js';
 import { handleGetJournal, handleSearchJournals } from './handlers/journals.js';
 import { handleReadResource } from './handlers/resources.js';
@@ -83,9 +91,78 @@ export async function routeToolRequest(
       }
       return handleGetActorDetails(args as { actorId: string }, foundryClient);
 
+    // Actor mutation tools (#143, require REST API module)
+    case 'update_actor_attributes':
+      if (!('actorId' in args) || typeof args.actorId !== 'string') {
+        throw new Error('Missing required parameter: actorId');
+      }
+      if (!('patch' in args) || typeof args.patch !== 'object' || args.patch === null) {
+        throw new Error('Missing required parameter: patch');
+      }
+      return handleUpdateActorAttribute(
+        args as { actorId: string; patch: AttributePatch },
+        foundryClient,
+      );
+
     // Item tools
     case 'search_items':
       return handleSearchItems(args, foundryClient);
+
+    // Compendium tools (#144)
+    case 'search_compendium':
+      if (!('query' in args) || typeof args.query !== 'string') {
+        throw new Error('Missing required parameter: query');
+      }
+      return handleSearchCompendium(
+        args as {
+          query: string;
+          filters?: {
+            compendiumId?: string;
+            packType?: string;
+            itemType?: string;
+            spellLevel?: number;
+            source?: string;
+          };
+          limit?: number;
+          cursor?: string;
+        },
+        foundryClient,
+      );
+
+    // Item mutation tools (WRITE — require REST API module)
+    case 'create_actor_item':
+      if (!('actorId' in args) || typeof args.actorId !== 'string') {
+        throw new Error('Missing required parameter: actorId');
+      }
+      if (!('source' in args) || typeof args.source !== 'object' || args.source === null) {
+        throw new Error('Missing required parameter: source');
+      }
+      return handleCreateActorItem(
+        args as { actorId: string; source: ActorItemCreateSource },
+        foundryClient,
+      );
+    case 'update_actor_item':
+      if (!('actorId' in args) || typeof args.actorId !== 'string') {
+        throw new Error('Missing required parameter: actorId');
+      }
+      if (!('itemId' in args) || typeof args.itemId !== 'string') {
+        throw new Error('Missing required parameter: itemId');
+      }
+      if (!('patch' in args) || typeof args.patch !== 'object' || args.patch === null) {
+        throw new Error('Missing required parameter: patch');
+      }
+      return handleUpdateActorItem(
+        args as { actorId: string; itemId: string; patch: Record<string, unknown> },
+        foundryClient,
+      );
+    case 'delete_actor_item':
+      if (!('actorId' in args) || typeof args.actorId !== 'string') {
+        throw new Error('Missing required parameter: actorId');
+      }
+      if (!('itemId' in args) || typeof args.itemId !== 'string') {
+        throw new Error('Missing required parameter: itemId');
+      }
+      return handleDeleteActorItem(args as { actorId: string; itemId: string }, foundryClient);
 
     // Scene tools
     case 'get_scene_info':


### PR DESCRIPTION
## Summary

Three FoundryVTT MCP tool capabilities. **Write tools now run over the primary Socket.IO transport** (FoundryVTT's core `modifyDocument` protocol) — not the secondary REST/`apiKey` path — so they function in the default username/password deployment.

- **#143 `update_actor_attributes`** — patch dot-paths into `actor.system` (HP, temp, currency, resources, spell slots, exhaustion). Validates HP ≤ max+temp, slots ≤ max, exhaustion 0–10 (2024) / 0–6 (2014); echoes post-update values. Emits an `Actor` `update` with `system.`-prefixed keys.
- **#142 `create_actor_item` / `update_actor_item` / `delete_actor_item`** — embedded `Item` create/update/delete with `parentUuid: "Actor.<id>"`. `update` applies a recursive JSON-merge patch to `item.system` (D&D 5e v4+ activity schema). Inline create only; compendium-source create is rejected over Socket.IO for now (needs a pack read — see #159).
- **#144 `search_compendium`** — read-only compendium search with cursor pagination. Stays on the REST path (graceful-empty without `apiKey`); compendium reads don't map to `modifyDocument`.

## Transport & gating

- Writes go through the existing authenticated Socket.IO session via `emitWithAck` → `modifyDocument`, gated by **`FOUNDRY_WRITE_ENABLED=true`** + an active connection (`assertWriteable`). The connected user needs GM/owner permission.
- After writes, `worldData` is stale per PRD-003 — use `refresh_world_data`.

## Protocol provenance

The `modifyDocument` request/response shape is **verified against the FoundryVTT v13.348 client source** (`client/data/client-backend.mjs` `#buildRequest`, `helpers/socket-interface.mjs` `dispatch`, `common/abstract/socket.mjs`) — not guessed. Full reference captured in #159.

## Tests

`just qa` green: biome + tsc + **190 Vitest tests**. Client-level tests mock the socket and assert the exact `modifyDocument` payloads (`Actor`/`Item`, `parentUuid`, `system.`-prefixed updates, write guards, compendium-source rejection). HP validation covered for both REST-raw and socket-mapped actor shapes.

## Remaining / follow-ups (#159)

- A live `actor.update` round-trip against a running v13 world is still worth running as a smoke test (the protocol is source-verified; a live pass confirms permissions + result echo).
- Compendium-source item create and compendium search over Socket.IO need a pack-read design.

Closes #142
Closes #143
Closes #144
