### PR TITLE
docs(rules): align dev commands with bun/just; add Foundry write-protocol rule

### DIFF
--- a/.claude/rules/development.md
+++ b/.claude/rules/development.md
@@ -15,11 +15,22 @@ Include scope when applicable: `feat(tools):`, `fix(auth):`
 
 ## Build & Test
 
-- `npm run build` before committing TypeScript changes
-- `npm test` for unit tests (Vitest)
-- `npm run test:e2e` for end-to-end tests (Playwright)
-- `npm run lint` for code quality checks
-- `just antipatterns` for ast-grep anti-pattern scanning
+This project uses **bun** as the package manager and **`just`** as the task
+runner (`bun.lock`, `justfile`). Prefer the `just` recipes — they are what CI
+runs and keep local/CI parity.
+
+- `just qa` — one-shot gate before committing: biome lint + `tsc` + Vitest. Run this first.
+- `just check-types` — `tsc --noEmit` only
+- `just test` — unit tests (Vitest); `just test-coverage` for coverage
+- `just lint` / `just lint-fix` — biome check (the linter+formatter); `lint-fix` auto-fixes
+- `just build` — compile TypeScript
+- `just test-e2e` — end-to-end tests (Playwright, headless)
+- `just antipatterns` — ast-grep anti-pattern scan
+
+A pre-commit hook (lint-staged) runs `biome check --write` on staged files, so
+formatting is auto-applied at commit time. When only specific files need
+formatting (e.g. avoiding pre-existing lint debt elsewhere), run
+`bunx biome check --write <paths>` on just those files.
 
 ## Type Safety
 

--- a/.claude/rules/foundry-write-protocol.md
+++ b/.claude/rules/foundry-write-protocol.md
@@ -1,0 +1,70 @@
+---
+paths:
+  - "src/foundry/**"
+  - "src/tools/**"
+---
+
+# FoundryVTT Transport & Write Protocol
+
+How the MCP server talks to FoundryVTT, and how to perform game-state
+mutations. Read this before adding any tool that reads or (especially) writes
+FoundryVTT documents.
+
+## Two transports — Socket.IO is primary
+
+| Mode | Trigger | What it does |
+|------|---------|--------------|
+| **Socket.IO** (primary) | `FOUNDRY_USERNAME` + `FOUNDRY_PASSWORD` | Authenticates a real Foundry client session (4-step `/join` flow in `auth.ts`), connects to `FOUNDRY_URL` (`:30000`), and loads a read-only `worldData` snapshot. Reads are served from that cache. |
+| **REST / `apiKey`** (secondary) | `FOUNDRY_API_KEY` set | Hits `/api/*` on the REST module / bridge. Optional — per the README it powers "REST API diagnostics". May be extracted (`feat/extract-rest-api-module`). |
+
+`.env.example` states Socket.IO is the primary method and `FOUNDRY_API_KEY` is
+commented out. **Do not assume the bridge/REST path is in use** — default
+deployments are Socket.IO-only. The bridge repo (`foundryvtt-local-rest-api`)
+is local-only (no remote) with active WIP; treat it as out-of-scope.
+
+## Writes use the core `modifyDocument` Socket.IO protocol
+
+Mutations go over the existing authenticated socket (no bridge), per PRD-003
+(`docs/prds/write-operations.md`). The transport lives in `client.ts`:
+`assertWriteable()` → `emitWithAck()` → `modifyDocument()`.
+
+- **Gate**: writes require `FOUNDRY_WRITE_ENABLED=true` **and** an active socket
+  (`assertWriteable`). The connected user needs GM/owner permission.
+- **Request** (standard Socket.IO ack callback): `socket.emit("modifyDocument", request, cb)` where
+  `request = { type, action, operation }`:
+  - `type`: document name — `"Actor"`, `"Item"`, …
+  - `action`: `"create" | "update" | "delete"`
+  - `operation`: `data:[…]` (create) / `updates:[{_id, …}]` (update) / `ids:[…]` (delete),
+    plus `broadcast:true`, `pack:null`, and — for embedded docs —
+    `parentUuid:"Actor.<actorId>"`.
+- **Response**: `{ type, action, operation, userId, result: object[]|string[], error? }`.
+  Reject on `response.error`; `result` holds created/updated data or deleted ids.
+- Actor `system` updates take **dot-notation keys prefixed with `system.`**
+  (e.g. `"system.attributes.hp.value"`); Foundry merges recursively.
+- After a write, `worldData` is stale — document it / expose `refresh_world_data`
+  (the `refreshWorldData()` method re-emits `world`). Do not assume the cache updated.
+
+## Verify the protocol against the bundled app source — don't guess
+
+The exact wire shape is FoundryVTT-version-specific and **not reliably
+documented on the web** (the wiki is JS-rendered). The authoritative source is
+the actual app, shipped unminified under `data/container_cache/foundryvtt-<ver>.zip`:
+
+```
+unzip -o -q data/container_cache/foundryvtt-13.348.zip 'resources/app/client/data/client-backend.mjs' -d /tmp/fvtt
+```
+
+Key files: `client/data/client-backend.mjs` (`#buildRequest`/`#dispatchRequest`),
+`client/helpers/socket-interface.mjs` (`dispatch` = emit-with-ack), and
+`common/abstract/socket.mjs` + `common/abstract/_types.mjs` (response shape and
+per-action `operation` fields). When implementing a new write feature
+(combat, tokens, scenes — PRD-003 FR-018…FR-024), confirm the shape there
+first, then smoke-test one round-trip against a live world.
+
+## What does NOT map to `modifyDocument`
+
+Compendium reads (`search_compendium`, compendium-source item create) use
+`CompendiumCollection.getDocuments` / the pack index — a separate socket path,
+not `modifyDocument`. Currently `search_compendium` stays on the REST path
+(graceful-empty without `apiKey`) and compendium-source create is rejected over
+Socket.IO. Design a pack-read path before adding compendium writes.


### PR DESCRIPTION
## Summary

Project-knowledge distilled while implementing the actor write tools (#142/#143/#144) and the Socket.IO rework (#159). Two `.claude/rules/` changes, no code.

### `development.md` — align Build & Test with actual tooling
The rule listed `npm run build` / `npm test` / `npm run lint`, but this project uses **bun** (`bun.lock`) and **`just`** (`justfile`). Replaced with the real recipes — `just qa` (lint + types + tests) as the one-shot gate, plus `check-types` / `test` / `lint-fix` / `build` / `test-e2e` — and a note on the lint-staged pre-commit auto-format.

### `foundry-write-protocol.md` (new) — transport & write protocol
Path-scoped to `src/foundry/**` + `src/tools/**`. Captures architecture that wasn't written down anywhere:
- **Socket.IO is the primary transport** (username/password → read-only `worldData`); REST/`apiKey` is secondary/optional. Don't assume the bridge is in use.
- **Writes use FoundryVTT's core `modifyDocument`** over the authenticated socket (`{type, action, operation}`, `parentUuid` for embedded docs), gated by `FOUNDRY_WRITE_ENABLED`.
- **Verify the version-specific wire shape against the bundled app source** (`data/container_cache/foundryvtt-*.zip` ships unminified `.mjs`) rather than guessing — with the exact files to read.
- Notes what doesn't map to `modifyDocument` (compendium reads).

Front-loads the knowledge for the remaining PRD-003 write features (combat, tokens, scenes, journals, macros).

Distilled via `/project:distill`. Independent of #158 — intentionally a separate PR. Does not close any issue.