### PR TITLE
test(integration): cover actor write tools end-to-end (#142, #143, #144)

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,20 +1,37 @@
 # Testing Requirements
 
-## Unit Tests (Vitest)
+This project uses **bun** + **`just`** (see `development.md` for the full
+command reference). Prefer the `just` recipes — they are what CI runs, keeping
+local/CI parity.
 
-- All new functions require corresponding unit tests
-- Run with `npm test` or `npm run test:watch`
-- Coverage reports via `npm run test:coverage`
+## Tiers
 
-## E2E Tests (Playwright)
+| Tier | Command | Scope |
+|------|---------|-------|
+| Unit | `just test` (`bun test`) | Pure logic, handlers, client methods with mocked I/O. New functions require unit tests; `just test-coverage` for coverage. |
+| Integration | `bun run test:integration` | `tests/integration/**` against a **live** FoundryVTT (`docker-compose.test.yml`, port 30001). Real Socket.IO auth + worldData. |
+| E2E | `just test-e2e` (`bun run test:e2e`) | Playwright smoke specs (`tests/e2e/**`). |
+| Gate | `just qa` | biome + `tsc` + unit Vitest — run before committing. |
 
-- Test against live FoundryVTT instance
-- Default headless mode: `npm run test:e2e`
-- Debug mode: `npm run test:e2e:debug`
+## Integration tier (live FoundryVTT)
 
-## Test Categories
+- Connects through the shared helper `tests/integration/setup.ts`
+  (`createConnectedClient`) in Socket.IO mode (`FOUNDRY_USERNAME`/`FOUNDRY_PASSWORD`).
+- `tests/integration/global-setup.ts` waits for the container to be ready.
+- **Write-tool tests** (`mutations.integration.test.ts`) exercise the
+  `modifyDocument` write protocol: they require `writeEnabled: true` and a world
+  **GM** user, target an actor with a mutable attribute, and **revert every
+  mutation**. When no mutable actor / world is available they `ctx.skip()`
+  rather than fail — matching the live-world precondition of the other
+  integration specs.
+- The bridge/REST path is **read-only**; `search_compendium` integration
+  coverage is blocked on the bridge implementing `/api/compendium/search`.
+- CI runs this tier only once the `FOUNDRY_*` secrets are configured (issue #140).
 
-- Module visibility and functionality
-- REST API endpoint accessibility
-- Authentication flows
-- Socket.IO connection handling
+## Coverage areas
+
+- Tool handlers (read **and** write) and the Socket.IO `modifyDocument` protocol
+  (see `foundry-write-protocol.md`)
+- Authentication (4-step Socket.IO join) and connection lifecycle
+- `foundry://` resource URIs and tool/contract schemas
+- World-data caching and querying

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Model Context Protocol (MCP) server bridging AI assistants with FoundryVTT table
 
 - **Language**: TypeScript (ES modules, `.js` imports for MCP SDK compatibility)
 - **Runtime**: Node.js (Bun as package manager)
-- **Test**: Vitest (unit), Playwright (E2E)
+- **Test**: Vitest (unit + integration), Playwright (E2E)
 - **Lint/Format**: Biome (linting + formatting)
 - **Validation**: Zod schemas
 
@@ -16,6 +16,7 @@ Model Context Protocol (MCP) server bridging AI assistants with FoundryVTT table
 bun run build          # Compile TypeScript
 bun run dev            # Development mode with hot reload
 bun test               # Unit tests (Vitest)
+bun run test:integration # Integration tests (live FoundryVTT, port 30001)
 bun run test:e2e       # E2E tests (Playwright, headless)
 bun run lint           # Lint code (Biome)
 bun run lint:fix       # Auto-fix lint issues
@@ -56,7 +57,8 @@ bun run test-connection # Test MCP→FoundryVTT connection
 | `FOUNDRY_USERNAME` | Yes | FoundryVTT user |
 | `FOUNDRY_PASSWORD` | Yes | FoundryVTT password |
 | `FOUNDRY_USER_ID` | No | Bypass username→ID resolution |
-| `FOUNDRY_API_KEY` | No | REST API module key |
+| `FOUNDRY_API_KEY` | No | REST API module key (read-only diagnostics path) |
+| `FOUNDRY_WRITE_ENABLED` | No | Enable game-state mutations — `true` required for the write tools (default `false`) |
 | `LOG_LEVEL` | No | `debug` for verbose output |
 | `FOUNDRY_TIMEOUT` | No | Request timeout (ms, default 10000) |
 
@@ -64,7 +66,8 @@ bun run test-connection # Test MCP→FoundryVTT connection
 
 See `.claude/rules/` for detailed guidelines:
 - `development.md` — TDD workflow, commit conventions, build commands
-- `testing.md` — Unit and E2E test requirements
+- `testing.md` — Test tiers (unit, integration, E2E) and requirements
+- `foundry-write-protocol.md` — transport (Socket.IO vs REST) and the `modifyDocument` write protocol
 - `document-management.md` — Document detection and organization
 
 ## Reference

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,6 +5,10 @@ services:
       - "30001:30000"
     environment:
       - FOUNDRY_LICENSE_KEY=${FOUNDRY_LICENSE_KEY}
+      # Pin the build so integration tests always run against the version the
+      # modifyDocument wire shape is verified against (client.ts), instead of
+      # whatever "latest" felddy resolves to (which also risks 429 rate-limits).
+      - FOUNDRY_VERSION=${FOUNDRY_VERSION:-13.348}
       - FOUNDRY_ADMIN_KEY=integration-test-admin
       - FOUNDRY_USERNAME=${FOUNDRY_USERNAME:-test-user}
       - FOUNDRY_PASSWORD=${FOUNDRY_PASSWORD:-test-password}

--- a/tests/integration/mutations.integration.test.ts
+++ b/tests/integration/mutations.integration.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Integration tests for the actor write tools (#142–144): item CRUD and
+ * attribute mutation over the FoundryVTT `modifyDocument` Socket.IO protocol.
+ *
+ * Unlike the handler unit tests (which mock the client), these drive real
+ * game-state mutations against a live world, so they require:
+ *   - a launched world with at least one actor exposing a numeric
+ *     `system.currency.gp` (dnd5e), and
+ *   - the connected user to hold GM/owner permission (writes are GM-gated).
+ *
+ * When no mutable actor is present — e.g. the fresh, world-less CI instance
+ * (issue #140) or a non-dnd5e system — the suite skips rather than failing,
+ * matching the live-world precondition shared by the other integration specs.
+ *
+ * Every mutation is reverted: the created item is deleted and the poked
+ * attribute is restored to its original value, leaving world state unchanged.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { FoundryClient } from '../../src/foundry/client.js';
+import { createConnectedClient } from './setup.js';
+
+interface MutableTarget {
+  id: string;
+  name: string;
+  gp: number;
+}
+
+describe('Actor write operations', () => {
+  let client: FoundryClient;
+  let target: MutableTarget | null = null;
+  let createdItemId: string | undefined;
+
+  beforeAll(async () => {
+    // Writes are opt-in (FOUNDRY_WRITE_ENABLED) and require the Socket.IO
+    // transport; the shared helper connects with username/password.
+    client = await createConnectedClient({ writeEnabled: true });
+
+    // Find an actor with a numeric system.currency.gp to safely poke. This
+    // doubles as the skip gate: a world-less instance yields no candidates.
+    const { actors } = await client.searchActors({ limit: 500 });
+    for (const actor of actors) {
+      const raw = client.getRawActor(actor._id) as
+        | { system?: { currency?: { gp?: unknown } } }
+        | undefined;
+      const gp = raw?.system?.currency?.gp;
+      if (typeof gp === 'number') {
+        target = { id: actor._id, name: actor.name, gp };
+        break;
+      }
+    }
+  });
+
+  afterAll(async () => {
+    // Best-effort cleanup if a test left the item behind (e.g. delete failed).
+    if (client && target && createdItemId) {
+      await client.deleteActorItem(target.id, createdItemId).catch(() => {});
+    }
+    if (client) {
+      await client.disconnect();
+    }
+  });
+
+  it('create_actor_item adds an inline item to an actor', (ctx) => {
+    if (!target) {
+      return ctx.skip();
+    }
+    return (async () => {
+      const created = await client.createActorItem(target!.id, {
+        type: 'inline',
+        item: {
+          name: 'MCP integration test item',
+          type: 'loot',
+          system: { quantity: 1 },
+        } as never,
+      });
+      createdItemId = (created as { _id?: string })._id;
+      expect(createdItemId).toBeTruthy();
+      expect(created).toMatchObject({ name: 'MCP integration test item' });
+    })();
+  });
+
+  it('update_actor_item patches the item system data', (ctx) => {
+    if (!target || !createdItemId) {
+      return ctx.skip();
+    }
+    return (async () => {
+      const updated = await client.updateActorItem(target!.id, createdItemId!, { quantity: 3 });
+      expect(updated).toBeTruthy();
+      // The server echoes the updated document; when present, quantity reflects the patch.
+      const quantity = (updated as { system?: { quantity?: number } })?.system?.quantity;
+      if (quantity !== undefined) {
+        expect(quantity).toBe(3);
+      }
+    })();
+  });
+
+  it('update_actor_attributes mutates then restores currency.gp', (ctx) => {
+    if (!target) {
+      return ctx.skip();
+    }
+    return (async () => {
+      const set = await client.updateActorAttribute(target!.id, { 'currency.gp': target!.gp + 1 });
+      expect(set.success).toBe(true);
+      expect(set.updatedAttributes).toHaveProperty('currency.gp');
+
+      // Restore the original value so world state is left unchanged.
+      const restored = await client.updateActorAttribute(target!.id, {
+        'currency.gp': target!.gp,
+      });
+      expect(restored.success).toBe(true);
+    })();
+  });
+
+  it('delete_actor_item removes the created item', (ctx) => {
+    if (!target || !createdItemId) {
+      return ctx.skip();
+    }
+    return (async () => {
+      await expect(client.deleteActorItem(target!.id, createdItemId!)).resolves.toBeUndefined();
+      createdItemId = undefined;
+    })();
+  });
+});

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -8,11 +8,12 @@ export default defineConfig({
     testTimeout: 30000,
     hookTimeout: 120000,
     pool: 'forks',
-    poolOptions: {
-      forks: {
-        singleFork: true,
-      },
-    },
+    // Vitest 4 removed test.poolOptions; the previous
+    // poolOptions.forks.singleFork is now maxWorkers + isolate (run the
+    // integration suite serially in one process against the single shared
+    // FoundryVTT instance). See https://vitest.dev/guide/migration#pool-rework
+    maxWorkers: 1,
+    isolate: false,
     env: {
       NODE_ENV: 'test',
       FOUNDRY_URL: 'http://localhost:30001',


### PR DESCRIPTION
## What

Adds end-to-end integration coverage for the four actor **write tools** (#142, #143, #144), lands two uniformity fixes for the integration harness, and brings the test/architecture docs in line with the current architecture.

### Coverage
- `tests/integration/mutations.integration.test.ts` exercises the real `modifyDocument` Socket.IO write path against a live FoundryVTT world:
  - `create_actor_item` (inline loot item)
  - `update_actor_item` (patch quantity)
  - `update_actor_attributes` (mutate `currency.gp`, then restore)
  - `delete_actor_item` (cleanup)
- Every mutation is reverted — created item deleted, attribute restored — so world state is left unchanged.
- Follows existing integration conventions (`createConnectedClient` + `setup.js`, `beforeAll`/`afterAll`, `*.integration.test.ts`). When no mutable actor is present (the world-less CI instance per #140, or a non-dnd5e system) the suite **skips** rather than failing, matching the live-world precondition of the other integration specs.

### Why this matters
The handler unit tests mock the client, so these four tools previously had **no coverage exercising the actual write protocol** against a live world.

### Uniformity follow-ups
- **`docker-compose.test.yml`**: pin `FOUNDRY_VERSION` (default `13.348`, overridable) so integration tests run against the build the `modifyDocument` wire shape in `client.ts` is verified against — instead of whatever "latest" felddy resolves to (which drifts and risks 429 rate-limits). Mirrors the same pin in the `foundryvtt-dev` test harness.
- **`vitest.integration.config.ts`**: migrate the Vitest-4-removed `test.poolOptions` (`poolOptions.forks.singleFork`) to the top-level equivalent (`maxWorkers: 1`, `isolate: false`), preserving serial single-process execution against the shared instance and clearing the deprecation warning.

### Docs currency
- **`.claude/rules/testing.md`**: rewritten around bun/just (was `npm`) and now documents the **integration tier** (live FoundryVTT on :30001), the write-tool test preconditions (GM user + `FOUNDRY_WRITE_ENABLED`), skip-when-no-world behaviour, and the read-only-bridge / `search_compendium` gap.
- **`CLAUDE.md`**: document `FOUNDRY_WRITE_ENABLED` (the write gate was undocumented), add the `test:integration` command and tier, and list the existing `foundry-write-protocol.md` rule (previously omitted from the Rules section).

## Verification
Run against a live dnd5e world (FoundryVTT 13.348):
- `mutations.integration.test.ts` → **4 passed**
- Migrated integration config loads with **no deprecation warning**, suite stays green
- `tsc --noEmit` clean

## Notes
- The integration suite (including this test) only runs in CI once the `FOUNDRY_*` secrets are configured — see #140.
- `search_compendium` (the 5th recent tool) is intentionally **not** covered here: it's REST/bridge-path only and the bridge doesn't yet implement `/api/compendium/search`. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
