### PR TITLE
chore(ci): mint release-please token via GitHub App, not expired PAT

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,10 +18,17 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v5
         id: release
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 


### PR DESCRIPTION
## What

Replaces the expired `RELEASE_PLEASE_TOKEN` PAT with a short-lived token minted by the Release Please GitHub App (`actions/create-github-app-token@v3`). The action version (`@v5`), publish job, permissions, and outputs are unchanged — **only the token source moves**.

```diff
+ - name: Generate GitHub App Token
+   id: app-token
+   uses: actions/create-github-app-token@v3
+   with:
+     app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+     private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+
  - uses: googleapis/release-please-action@v5
    with:
-     token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+     token: ${{ steps.app-token.outputs.token }}
```

## Why

Every release-please run since 2026-03-13 has failed with `Bad credentials`: the `RELEASE_PLEASE_TOKEN` PAT (created 2026-03-06) expired. As a result `1.0.1` was bumped in-repo but never tagged or published (npm still at `1.0.0`). This matches `pal-mcp-server` / `scansift` / `claude-plugins`.

## ⚠️ Depends on laurigates/gitops#103 — held as draft

Do **not** merge until laurigates/gitops#103 has merged **and** Scalr has applied. That apply is what creates `vars.RELEASE_PLEASE_APP_ID` and `secrets.RELEASE_PLEASE_PRIVATE_KEY` on this repo; merging early fails the workflow with empty App creds.

## Verification & follow-ups

- The first run after merge verifies the App is installed on this repo (if installed "selected repositories only", it fails with `resource not accessible` and the repo must be added to the App installation).
- Expect a `2.0.0` release PR — there's a breaking change in history since `1.0.1`.
- Post-merge cleanup tracked in #164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
