### PR TITLE
chore(rules): document release pipeline auth, add release-status recipe

### DIFF
--- a/.claude/rules/release-pipeline.md
+++ b/.claude/rules/release-pipeline.md
@@ -1,0 +1,41 @@
+---
+paths:
+  - "**/release-please.yml"
+  - "**/release-please-config.json"
+  - "**/.release-please-manifest.json"
+---
+
+# Release Pipeline
+
+Releases via **release-please** + npm publish (`.github/workflows/release-please.yml`).
+
+## Auth: gitops-managed GitHub App, never a PAT
+
+The workflow mints a short-lived token from the **Release Please GitHub App**:
+
+```yaml
+- uses: actions/create-github-app-token@v3
+  id: app-token
+  with:
+    app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+    private-key: ${{ secrets.RELEASE_PLEASE_PRIVATE_KEY }}
+- uses: googleapis/release-please-action@v5
+  with:
+    token: ${{ steps.app-token.outputs.token }}
+```
+
+`RELEASE_PLEASE_APP_ID` (var) + `RELEASE_PLEASE_PRIVATE_KEY` (secret) are
+distributed by **gitops** to every repo flagged `release_please = true` in
+`laurigates/gitops/repositories.tf`. Do **not** reintroduce a standalone PAT
+(`RELEASE_PLEASE_TOKEN`) — a PAT expires silently and stalls releases until
+someone notices npm has gone stale (this exact failure cost ~3 months once).
+
+## Failure modes
+
+| Run-log symptom | Cause | Fix |
+|---|---|---|
+| `release-please failed: Bad credentials` | App creds missing/expired, or repo not `release_please = true` in gitops | Confirm `gh variable list` / `gh secret list` show the App ID + private key; if absent, flip the gitops flag and let Scalr apply |
+| `resource not accessible by integration` | Release Please App not installed on this repo | Add the repo to the App installation (GitHub → Settings → Installed GitHub Apps) |
+
+Tag scheme: `foundryvtt-mcp-v<version>` (package name as component). Health
+check: `just release-status`.

--- a/justfile
+++ b/justfile
@@ -247,6 +247,29 @@ antipatterns:
 publish-dry-run: build
     npm publish --dry-run --access public
 
+# Show release-please health: recent runs, open release PR, version drift
+[group: "publish"]
+release-status:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "=== Recent release-please runs ==="
+    gh run list --workflow=release-please.yml --limit 3 \
+      --json createdAt,status,conclusion,event \
+      --jq '.[] | "\(.createdAt)  \(.status)/\(.conclusion // "running")  \(.event)"'
+    echo ""
+    echo "=== Open release PR ==="
+    prs=$(gh pr list --state open --label "autorelease: pending" \
+      --json number,title --jq '.[] | "#\(.number) \(.title)"')
+    [ -n "$prs" ] && echo "$prs" || echo "(none)"
+    echo ""
+    echo "=== Version drift ==="
+    name=$(node -p "require('./package.json').name")
+    local_v=$(node -p "require('./package.json').version")
+    npm_v=$(npm view "$name" version 2>/dev/null || echo "unpublished")
+    tag_v=$(git describe --tags --abbrev=0 2>/dev/null || echo "none")
+    printf "  package.json: %s\n  npm latest:   %s\n  latest tag:   %s\n" "$local_v" "$npm_v" "$tag_v"
+    [ "$local_v" = "$npm_v" ] || echo "  ! package.json $local_v not on npm ($npm_v)"
+
 ########## Composite Workflows ##########
 
 # Quick development check (lint + test)


### PR DESCRIPTION
## What

Distilled from this session's release-please outage fix (#165). Two reusable artifacts:

- **`.claude/rules/release-pipeline.md`** — path-scoped to release-please files (`release-please.yml`, config, manifest). Documents the gitops-managed GitHub App auth model and the two failure modes (`Bad credentials`, `resource not accessible by integration`) with their fixes, so the next person doesn't re-derive them.
- **`just release-status`** — one-command health check: recent release-please runs, any open release PR, and `package.json` vs npm vs latest-tag drift. This is exactly the check that would have caught the silent breakage (the expired PAT went unnoticed for ~3 months because npm quietly stopped updating).

## Why

The release auth model and its failure modes weren't documented anywhere in the repo — part of why the outage went unnoticed. These make release health checkable on demand and the failure mode findable in the rules.

## Notes

- Independent of the gitops dependency that gated #165 — this needs nothing from gitops and can merge anytime.
- `just release-status` verified locally; correctly reports the current `1.0.1` (repo) vs `1.0.0` (npm) drift that #165 + the next release PR will resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
