### PR TITLE
ci: publish via reusable OIDC trusted-publishing workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,30 +35,9 @@ jobs:
   publish:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          registry-url: https://registry.npmjs.org
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build
-        run: bun run build
-
-      - name: Publish to npm
-        run: npm publish --access public --provenance
+      id-token: write # OIDC for npm trusted publishing
+    uses: laurigates/.github/.github/workflows/reusable-npm-publish.yml@main
+    with:
+      node-version: "24"


### PR DESCRIPTION
Switches the npm publish job to the shared `reusable-npm-publish.yml` (laurigates/.github#13) — OIDC trusted publishing, no `NPM_TOKEN`, npm auto-upgraded to ≥ 11.5.1.

The previous inline job already published tokenless (`--provenance`, `id-token: write`), so this is mostly a DRY consolidation onto the shared workflow + the npm-version guarantee. Node version preserved at 24.

### Prerequisite
Trusted publisher for `foundryvtt-mcp` must point at this repo + `release-please.yml`. Verify with `npm trust list foundryvtt-mcp`; if missing:

```
npm trust github foundryvtt-mcp --file release-please.yml --repository laurigates/foundryvtt-mcp --allow-publish
```

### Merge order
1. Merge laurigates/.github#13 (the reusable workflow) first — this caller pins `@main`.
2. Ensure the trusted publisher exists.
3. Merge this PR; next release publishes via OIDC.