### PR TITLE
feat(tools): combat control write tools (next_turn, end_combat, set_initiative)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ To configure manually, see the [Configuration Guide](docs/guides/configuration.m
 | `FOUNDRY_PASSWORD` | Yes | FoundryVTT user password |
 | `FOUNDRY_USER_ID` | No | Bypass username-to-ID resolution |
 | `FOUNDRY_API_KEY` | No | REST API module key (enables diagnostics tools) |
+| `FOUNDRY_WRITE_ENABLED` | No | Enable game-state mutations — `true` required for the write tools (default: `false`) |
 | `LOG_LEVEL` | No | `debug`, `info`, `warn`, or `error` (default: `info`) |
 | `FOUNDRY_TIMEOUT` | No | Request timeout in ms (default: `10000`) |
 
@@ -146,6 +147,20 @@ Ask your AI assistant things like:
 - `get_users` — list online users and their status
 - `get_combat_state` — combat state and initiative order
 - `get_chat_messages` — recent chat history
+
+### Write Operations (require `FOUNDRY_WRITE_ENABLED=true`)
+
+Game-state mutations are **disabled by default**. They use the Socket.IO
+`modifyDocument` protocol over an authenticated session, and the connected user
+needs GM/owner permission. Set `FOUNDRY_WRITE_ENABLED=true` to enable them.
+
+- `next_turn` — advance the active combat to the next turn (wraps to the next round)
+- `end_combat` — end (delete) the active combat encounter
+- `set_initiative` — set a combatant's initiative in the active combat
+- `update_actor_attributes` — patch an actor's `system` attributes (HP, currency, spell slots, …)
+- `create_actor_item` — add an inline item to an actor
+- `update_actor_item` — apply a JSON merge patch to an actor's item
+- `delete_actor_item` — remove an item from an actor
 
 ### World
 

--- a/docs/blueprint/feature-tracker.json
+++ b/docs/blueprint/feature-tracker.json
@@ -126,8 +126,9 @@
       "id": "FR-018",
       "name": "Combat management (start/end, advance initiative)",
       "prd": "PRD-001",
-      "status": "planned",
-      "priority": "high"
+      "status": "partial",
+      "priority": "high",
+      "note": "3/4 tools shipped (next_turn, end_combat, set_initiative); start_combat deferred (#172), skipDefeated refinement (#173)"
     },
     {
       "id": "FR-019",
@@ -147,8 +148,9 @@
       "id": "FR-021",
       "name": "Character sheet editing",
       "prd": "PRD-001",
-      "status": "planned",
-      "priority": "medium"
+      "status": "complete",
+      "priority": "medium",
+      "note": "Delivered by actor attribute + item CRUD mutations (update_actor_attributes, create/update/delete_actor_item)"
     },
     {
       "id": "FR-022",
@@ -174,8 +176,9 @@
   ],
   "summary": {
     "total": 24,
-    "complete": 17,
-    "planned": 7,
-    "completion_percentage": 70.8
+    "complete": 18,
+    "partial": 1,
+    "planned": 5,
+    "completion_percentage": 75.0
   }
 }

--- a/docs/blueprint/feature-tracker.md
+++ b/docs/blueprint/feature-tracker.md
@@ -19,10 +19,10 @@
 | Rule lookup | PRD-001 | complete | low |
 | MCP resource endpoints (foundry://) | PRD-001 | complete | medium |
 | Optional REST API diagnostics (logs, health) | PRD-002 | complete | low |
-| Combat management (start/end, advance initiative) | PRD-001 | planned | high |
+| Combat management (start/end, advance initiative) | PRD-001 | partial | high |
 | Token manipulation (move, status effects) | PRD-001 | planned | medium |
 | Scene navigation and switching | PRD-001 | planned | medium |
-| Character sheet editing | PRD-001 | planned | medium |
+| Character sheet editing | PRD-001 | complete | medium |
 | Journal creation and editing | PRD-001 | planned | low |
 | Macro execution | PRD-001 | planned | low |
 | Multi-world support | PRD-001 | planned | low |

--- a/docs/blueprint/manifest.json
+++ b/docs/blueprint/manifest.json
@@ -96,11 +96,24 @@
     "feature-tracker-sync": {
       "enabled": true,
       "auto_run": false,
-      "last_completed_at": null,
-      "last_result": null,
+      "last_completed_at": "2026-06-20T17:40:45Z",
+      "last_result": "success",
       "schedule": "daily",
-      "stats": {},
-      "context": {}
+      "stats": {
+        "runs_total": 1,
+        "features_updated": 2
+      },
+      "context": {
+        "updated": [
+          "FR-018 planned->partial",
+          "FR-021 planned->complete"
+        ],
+        "deferred_issues": [
+          172,
+          173,
+          174
+        ]
+      }
     },
     "sync-ids": {
       "enabled": true,

--- a/docs/prps/implement-write-operations.md
+++ b/docs/prps/implement-write-operations.md
@@ -8,7 +8,88 @@
 
 Add write operations to foundryvtt-mcp, starting with combat management (FR-018) as the highest-value first step.
 
-## Phase 1 Implementation Plan (FR-018 + FR-019)
+## Status (current)
+
+| Area | Status |
+|------|--------|
+| Write guard (`FOUNDRY_WRITE_ENABLED`) | ✅ Shipped — `assertWriteable()` in `src/foundry/client.ts`, config `writeEnabled` in `src/config/index.ts` |
+| Socket.IO write transport | ✅ Shipped — `modifyDocument()` (NOT the generic `emitWrite` originally sketched below); see "Design correction" |
+| Actor attribute mutation (FR-021) | ✅ Shipped — `update_actor_attributes` (#143) |
+| Actor item CRUD (FR-021) | ✅ Shipped — `create_actor_item` / `update_actor_item` / `delete_actor_item` (#142, #159) |
+| Combat write — `next_turn`, `end_combat`, `set_initiative` (FR-018) | ✅ Shipped — Phase 1a, this PRP |
+| Combat write — `start_combat` (FR-018) | ⏳ Deferred — [#172](https://github.com/laurigates/foundryvtt-mcp/issues/172) |
+| `next_turn` skipDefeated refinement | ⏳ Deferred — [#173](https://github.com/laurigates/foundryvtt-mcp/issues/173) |
+| Token manipulation (FR-019) | ⏳ Deferred — [#174](https://github.com/laurigates/foundryvtt-mcp/issues/174) |
+
+## Design correction: `modifyDocument`, not `emitWrite`
+
+The early sketch below proposed a generic `emitWrite(event, data)` helper. The
+implementation instead uses FoundryVTT's core **`modifyDocument`** Socket.IO
+protocol — the request shape verified against the bundled v13.348 app source
+(`client/data/client-backend.mjs` `#buildRequest`). All writes go through:
+
+```
+assertWriteable()  →  emitWithAck('modifyDocument', { type, action, operation })  →  modifyDocument()
+```
+
+where `operation` carries `data:[…]` (create) / `updates:[{_id,…}]` (update,
+with `diff`/`recursive`) / `ids:[…]` (delete), plus `parentUuid:"<Parent>.<id>"`
+for embedded documents (e.g. `Combatant` → `Combat.<combatId>`). See
+`.claude/rules/foundry-write-protocol.md`.
+
+## Combat Phase 1a (FR-018) — as shipped
+
+Three GM-gated tools operating on the **active** combat, disabled by default:
+
+- `next_turn` — advance turn; wraps to next round past the last combatant
+  (does not yet skip defeated combatants — [#173](https://github.com/laurigates/foundryvtt-mcp/issues/173))
+- `end_combat` — delete the active combat encounter
+- `set_initiative` — set a combatant's initiative (`combatId` defaults to active)
+
+Client methods: `updateCombat`, `endCombat`, `setCombatantInitiative`
+(`src/foundry/client.ts`). Pure helper `computeNextTurn` and handlers in
+`src/tools/handlers/combat-mutations.ts`.
+
+## Files (combat Phase 1a)
+
+| File | Action |
+|------|--------|
+| `src/foundry/client.ts` | `updateCombat` / `endCombat` / `setCombatantInitiative` |
+| `src/tools/handlers/combat-mutations.ts` | New — `computeNextTurn` + 3 handlers |
+| `src/tools/definitions.ts` | `combatMutationTools` + register in `getAllTools()` |
+| `src/tools/router.ts` | dispatch cases + imports |
+| `src/tools/handlers/__tests__/combat-mutations.test.ts` | New — unit tests (mocked socket) |
+| `tests/integration/combat.integration.test.ts` | New — gated live round-trip (skip/revert idiom) |
+| `README.md` | "Write Operations" subsection + `FOUNDRY_WRITE_ENABLED` env row |
+| `.env.example` | already documents `FOUNDRY_WRITE_ENABLED` |
+
+## Test Checklist
+
+- [x] Unit: all write handlers tested with mocked Socket.IO
+- [x] Unit: write guard returns error when `FOUNDRY_WRITE_ENABLED=false`
+- [x] Unit: emitted `modifyDocument` wire shape asserted (Combat update / delete, Combatant `parentUuid`)
+- [~] Integration: `set_initiative` + `next_turn` live round-trip+restore — gated; skips when no active GM combat or no licensed test instance (CI gap #140)
+
+## Deferred (separate issues)
+
+- `start_combat` (FR-018, highest-risk — creates Combat + Combatant docs): [#172](https://github.com/laurigates/foundryvtt-mcp/issues/172)
+- `next_turn` skipDefeated refinement: [#173](https://github.com/laurigates/foundryvtt-mcp/issues/173)
+- Token manipulation tools (FR-019 — move, status effects): [#174](https://github.com/laurigates/foundryvtt-mcp/issues/174)
+
+## Success Criteria
+
+- [x] All write tools disabled by default (`FOUNDRY_WRITE_ENABLED` not set)
+- [x] All write tools documented with clear opt-in instructions
+- [x] Unit test coverage for new handlers (every branch exercised; coverage tooling `@vitest/coverage-v8` not installed locally)
+- [x] No regressions in existing read-only tools
+
+---
+
+## Original Phase 1 sketch (superseded — retained for history)
+
+The steps below were the initial plan. Steps 1–2 shipped via a better
+mechanism (`modifyDocument`, see "Design correction"); the combat tools shipped
+in Phase 1a; token tools (Step 4) are deferred to [#174](https://github.com/laurigates/foundryvtt-mcp/issues/174).
 
 ### Step 1: Add write guard
 
@@ -22,6 +103,9 @@ FOUNDRY_WRITE_ENABLED: z.string().optional().transform(v => v === 'true'),
 All write tool handlers check this at the start and return an error if false.
 
 ### Step 2: Add Socket.IO write helper to FoundryClient
+
+> Superseded: implemented as `modifyDocument()` over `emitWithAck()`, not the
+> generic `emitWrite()` below.
 
 ```typescript
 // src/foundry/client.ts
@@ -41,67 +125,21 @@ async emitWrite<T>(event: string, data: unknown): Promise<T> {
 
 ### Step 3: Implement combat handler tools
 
-```typescript
-// src/tools/handlers/combat-write.ts
-export async function startCombat(client: FoundryClient, tokenIds: string[]): Promise<string>
-export async function endCombat(client: FoundryClient, combatId: string): Promise<void>
-export async function nextTurn(client: FoundryClient, combatId: string): Promise<CombatState>
-export async function setInitiative(client: FoundryClient, combatId: string, combatantId: string, initiative: number): Promise<void>
-```
+Shipped as `next_turn` / `end_combat` / `set_initiative` (`start_combat` deferred to [#172](https://github.com/laurigates/foundryvtt-mcp/issues/172)).
 
 ### Step 4: Implement token manipulation tools
 
-```typescript
-// src/tools/handlers/tokens.ts
-export async function moveToken(client: FoundryClient, tokenId: string, x: number, y: number): Promise<void>
-export async function applyStatusEffect(client: FoundryClient, tokenId: string, effect: string, active: boolean): Promise<void>
-```
+Deferred to [#174](https://github.com/laurigates/foundryvtt-mcp/issues/174).
 
 ### Step 5: Register tool schemas
 
-Add to `src/tools/definitions.ts`:
-- `start_combat`, `end_combat`, `next_turn`, `set_initiative`
-- `move_token`, `apply_status_effect`
+Done for combat tools in `src/tools/definitions.ts` (`combatMutationTools`).
 
 ### Step 6: Write unit tests
 
-```typescript
-// src/tools/handlers/__tests__/combat-write.test.ts
-// Mock socket.emit responses
-// Test: write guard blocks when disabled
-// Test: start_combat emits correct Socket.IO event
-// Test: error handling on Socket.IO failure
-```
+Done — `src/tools/handlers/__tests__/combat-mutations.test.ts` (mocked socket;
+guard, wire shape, error handling).
 
 ### Step 7: Update documentation
 
-- README: add "Write Operations" section with `FOUNDRY_WRITE_ENABLED` instructions
-- Add tool descriptions to API reference
-
-## Test Checklist
-
-- [ ] Unit: all write handlers tested with mocked Socket.IO
-- [ ] Unit: write guard returns error when `FOUNDRY_WRITE_ENABLED=false`
-- [ ] E2E: `start_combat` creates combat with correct tokens (requires live Foundry)
-- [ ] E2E: `next_turn` advances initiative correctly
-
-## Files to Create/Modify
-
-| File | Action |
-|------|--------|
-| `src/config/index.ts` | Add `FOUNDRY_WRITE_ENABLED` |
-| `src/foundry/client.ts` | Add `emitWrite()` helper |
-| `src/tools/handlers/combat-write.ts` | New file |
-| `src/tools/handlers/tokens.ts` | New file |
-| `src/tools/definitions.ts` | Add tool schemas |
-| `src/tools/registry.ts` | Register write tools |
-| `tests/unit/combat-write.test.ts` | New tests |
-| `README.md` | Document write ops |
-| `.env.example` | Add `FOUNDRY_WRITE_ENABLED=false` |
-
-## Success Criteria
-
-- All write tools disabled by default (`FOUNDRY_WRITE_ENABLED` not set)
-- All write tools documented with clear opt-in instructions
-- Unit test coverage ≥ 80% for new handlers
-- No regressions in existing read-only tools
+Done — README "Write Operations" subsection + `FOUNDRY_WRITE_ENABLED` env row.

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -721,6 +721,81 @@ export class FoundryClient {
   }
 
   // ==========================================================================
+  // Combat mutation methods (WRITE — Socket.IO modifyDocument, FR-018)
+  // ==========================================================================
+
+  /**
+   * Updates the active combat's turn/round pointers (FR-018).
+   *
+   * `Combat` is a top-level document, so the update carries no `parentUuid`.
+   * The patch fields map directly onto the Combat document (`turn`, `round`).
+   *
+   * @param combatId - 16-char alphanumeric Combat document id
+   * @param patch - turn and/or round to set on the combat
+   * @returns the updated combat document
+   */
+  async updateCombat(combatId: string, patch: { turn?: number; round?: number }): Promise<unknown> {
+    this.assertWriteable();
+    if (!FOUNDRY_ID_PATTERN.test(combatId)) {
+      throw new Error(`Invalid combatId format: ${combatId}`);
+    }
+    const result = await this.modifyDocument('Combat', 'update', {
+      updates: [{ _id: combatId, ...patch }],
+      diff: true,
+      recursive: true,
+    });
+    return result[0];
+  }
+
+  /**
+   * Ends (deletes) the active combat encounter (FR-018).
+   *
+   * @param combatId - 16-char alphanumeric Combat document id
+   */
+  async endCombat(combatId: string): Promise<void> {
+    this.assertWriteable();
+    if (!FOUNDRY_ID_PATTERN.test(combatId)) {
+      throw new Error(`Invalid combatId format: ${combatId}`);
+    }
+    await this.modifyDocument('Combat', 'delete', { ids: [combatId] });
+  }
+
+  /**
+   * Sets a combatant's initiative (FR-018).
+   *
+   * `Combatant` is an embedded document inside `Combat`, so the update is sent
+   * with `parentUuid: "Combat.<combatId>"`.
+   *
+   * @param combatId - 16-char alphanumeric Combat document id (the parent)
+   * @param combatantId - 16-char alphanumeric Combatant document id
+   * @param initiative - finite initiative value to assign
+   * @returns the updated combatant document
+   */
+  async setCombatantInitiative(
+    combatId: string,
+    combatantId: string,
+    initiative: number,
+  ): Promise<unknown> {
+    this.assertWriteable();
+    if (!FOUNDRY_ID_PATTERN.test(combatId)) {
+      throw new Error(`Invalid combatId format: ${combatId}`);
+    }
+    if (!FOUNDRY_ID_PATTERN.test(combatantId)) {
+      throw new Error(`Invalid combatantId format: ${combatantId}`);
+    }
+    if (typeof initiative !== 'number' || !Number.isFinite(initiative)) {
+      throw new Error(`Invalid initiative: ${initiative} (must be a finite number)`);
+    }
+    const result = await this.modifyDocument('Combatant', 'update', {
+      updates: [{ _id: combatantId, initiative }],
+      parentUuid: `Combat.${combatId}`,
+      diff: true,
+      recursive: true,
+    });
+    return result[0];
+  }
+
+  // ==========================================================================
   // Scene methods
   // ==========================================================================
 

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -476,6 +476,61 @@ export const combatTools = [
 ];
 
 /**
+ * Combat control mutation tool definitions (FR-018)
+ *
+ * WRITE operations — require FOUNDRY_WRITE_ENABLED=true and an active Socket.IO
+ * connection (mutations use the core `modifyDocument` protocol). All operate on
+ * the *active* combat; the connected user needs GM/owner permission.
+ */
+export const combatMutationTools = [
+  {
+    name: 'next_turn',
+    description:
+      'Advance the active combat to the next turn, wrapping to the next round after the last combatant. ' +
+      'Does not yet skip defeated combatants. ' +
+      'Requires FOUNDRY_WRITE_ENABLED=true and an active Socket.IO connection.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'end_combat',
+    description:
+      'End (delete) the active combat encounter. ' +
+      'Requires FOUNDRY_WRITE_ENABLED=true and an active Socket.IO connection.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'set_initiative',
+    description:
+      "Set a combatant's initiative in the active combat. " +
+      'Requires FOUNDRY_WRITE_ENABLED=true and an active Socket.IO connection.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        combatantId: {
+          type: 'string',
+          description: 'The ID of the combatant whose initiative to set',
+        },
+        initiative: {
+          type: 'number',
+          description: 'The initiative value to assign',
+        },
+        combatId: {
+          type: 'string',
+          description: 'Optional Combat document ID; defaults to the active combat',
+        },
+      },
+      required: ['combatantId', 'initiative'],
+    },
+  },
+];
+
+/**
  * Chat message tool definitions
  */
 export const chatTools = [
@@ -604,6 +659,7 @@ export function getAllTools() {
     ...itemMutationTools,
     ...sceneTools,
     ...combatTools,
+    ...combatMutationTools,
     ...chatTools,
     ...userTools,
     ...journalTools,

--- a/src/tools/handlers/__tests__/combat-mutations.test.ts
+++ b/src/tools/handlers/__tests__/combat-mutations.test.ts
@@ -1,0 +1,256 @@
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it, vi } from 'vitest';
+import { FoundryClient } from '../../../foundry/client.js';
+import type { WorldCombat } from '../../../foundry/types.js';
+import {
+  computeNextTurn,
+  handleEndCombat,
+  handleNextTurn,
+  handleSetInitiative,
+} from '../combat-mutations.js';
+
+const COMBAT_ID = 'cccccccccccccccc'; // 16 alphanumeric chars
+const COMBATANT_ID = 'dddddddddddddddd';
+
+/** Builds a minimal WorldCombat with `n` combatants. */
+const makeCombat = (overrides: Partial<WorldCombat> = {}): WorldCombat => ({
+  _id: COMBAT_ID,
+  active: true,
+  round: 1,
+  turn: 0,
+  started: true,
+  combatants: [
+    { _id: COMBATANT_ID, name: 'Alice', initiative: 15, hidden: false, defeated: false },
+    { _id: 'eeeeeeeeeeeeeeee', name: 'Bob', initiative: 10, hidden: false, defeated: false },
+  ],
+  ...overrides,
+});
+
+describe('computeNextTurn', () => {
+  it('advances to the next combatant mid-combat', () => {
+    const combat = makeCombat({ turn: 0, round: 1 });
+    expect(computeNextTurn(combat)).toEqual({ turn: 1, round: 1 });
+  });
+
+  it('wraps to turn 0 of the next round after the last combatant', () => {
+    const combat = makeCombat({ turn: 1, round: 1 });
+    expect(computeNextTurn(combat)).toEqual({ turn: 0, round: 2 });
+  });
+
+  it('treats a null turn as turn 0', () => {
+    const combat = makeCombat({ turn: null, round: 3 });
+    expect(computeNextTurn(combat)).toEqual({ turn: 1, round: 3 });
+  });
+
+  it('throws when the combat has no combatants', () => {
+    const combat = makeCombat({ combatants: [] });
+    expect(() => computeNextTurn(combat)).toThrow(/no combatants/);
+  });
+});
+
+describe('Combat mutation handlers', () => {
+  const createMockClient = (opts: {
+    combat?: WorldCombat | null;
+    updateCombat?: (id: string, patch: { turn?: number; round?: number }) => unknown;
+    endCombat?: (id: string) => unknown;
+    setInitiative?: (combatId: string, combatantId: string, initiative: number) => unknown;
+  }): FoundryClient =>
+    ({
+      getCombatState: vi.fn(() => opts.combat ?? null),
+      updateCombat: vi.fn(opts.updateCombat ?? (() => ({}))),
+      endCombat: vi.fn(opts.endCombat ?? (() => undefined)),
+      setCombatantInitiative: vi.fn(opts.setInitiative ?? (() => ({}))),
+    }) as unknown as FoundryClient;
+
+  describe('handleNextTurn', () => {
+    it('advances the active combat and reports the new round/turn/combatant', async () => {
+      const client = createMockClient({ combat: makeCombat({ turn: 0, round: 1 }) });
+      const result = await handleNextTurn({}, client);
+
+      const text = result.content[0].text;
+      expect(result.content[0].type).toBe('text');
+      expect(text).toContain('Combat Turn Advanced');
+      expect(text).toContain('**Round:** 1');
+      expect(text).toContain('Bob');
+      expect(client.updateCombat).toHaveBeenCalledWith(COMBAT_ID, { turn: 1, round: 1 });
+    });
+
+    it('raises McpError when there is no active combat', async () => {
+      const client = createMockClient({ combat: null });
+      await expect(handleNextTurn({}, client)).rejects.toThrow(McpError);
+      expect(client.updateCombat).not.toHaveBeenCalled();
+    });
+
+    it('propagates the write-disabled guard error', async () => {
+      const client = createMockClient({
+        combat: makeCombat(),
+        updateCombat: () => {
+          throw new Error(
+            'Write operations are disabled. Set FOUNDRY_WRITE_ENABLED=true to allow game-state mutation.',
+          );
+        },
+      });
+      await expect(handleNextTurn({}, client)).rejects.toThrow(/FOUNDRY_WRITE_ENABLED/);
+    });
+  });
+
+  describe('handleEndCombat', () => {
+    it('ends the active combat and reports the encounter id', async () => {
+      const client = createMockClient({ combat: makeCombat() });
+      const result = await handleEndCombat({}, client);
+
+      expect(result.content[0].text).toContain('Combat Ended');
+      expect(result.content[0].text).toContain(COMBAT_ID);
+      expect(client.endCombat).toHaveBeenCalledWith(COMBAT_ID);
+    });
+
+    it('raises McpError when there is no active combat', async () => {
+      const client = createMockClient({ combat: null });
+      await expect(handleEndCombat({}, client)).rejects.toThrow(McpError);
+      expect(client.endCombat).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleSetInitiative', () => {
+    it('sets initiative on the active combat by default', async () => {
+      const client = createMockClient({ combat: makeCombat() });
+      const result = await handleSetInitiative(
+        { combatantId: COMBATANT_ID, initiative: 18 },
+        client,
+      );
+
+      expect(result.content[0].text).toContain('Initiative Set');
+      expect(result.content[0].text).toContain('18');
+      expect(client.setCombatantInitiative).toHaveBeenCalledWith(COMBAT_ID, COMBATANT_ID, 18);
+    });
+
+    it('honours an explicit combatId', async () => {
+      const client = createMockClient({ combat: null });
+      await handleSetInitiative(
+        { combatantId: COMBATANT_ID, initiative: 5, combatId: COMBAT_ID },
+        client,
+      );
+      expect(client.setCombatantInitiative).toHaveBeenCalledWith(COMBAT_ID, COMBATANT_ID, 5);
+    });
+
+    it('rejects a missing combatantId before reaching the client', async () => {
+      const client = createMockClient({ combat: makeCombat() });
+      await expect(handleSetInitiative({ combatantId: '', initiative: 5 }, client)).rejects.toThrow(
+        McpError,
+      );
+      expect(client.setCombatantInitiative).not.toHaveBeenCalled();
+    });
+
+    it('rejects a non-finite initiative before reaching the client', async () => {
+      const client = createMockClient({ combat: makeCombat() });
+      await expect(
+        handleSetInitiative({ combatantId: COMBATANT_ID, initiative: Number.NaN }, client),
+      ).rejects.toThrow(McpError);
+      expect(client.setCombatantInitiative).not.toHaveBeenCalled();
+    });
+
+    it('raises McpError when no active combat and no combatId', async () => {
+      const client = createMockClient({ combat: null });
+      await expect(
+        handleSetInitiative({ combatantId: COMBATANT_ID, initiative: 5 }, client),
+      ).rejects.toThrow(McpError);
+      expect(client.setCombatantInitiative).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// --------------------------------------------------------------------------
+// Client-level: exercise the real methods with a mock socket, asserting the
+// emitted modifyDocument body (mirrors actor-mutations.test.ts).
+// --------------------------------------------------------------------------
+describe('FoundryClient combat mutations', () => {
+  type SocketEmitMock = (event: string, payload: unknown, cb: (response: unknown) => void) => void;
+
+  const buildClient = (opts: { writeEnabled?: boolean; connected?: boolean }) => {
+    const client = new FoundryClient({
+      baseUrl: 'http://localhost:30000',
+      writeEnabled: opts.writeEnabled ?? true,
+    });
+    const emit = vi.fn(((_event, payload, cb) => {
+      const op = (payload as { operation?: { updates?: Array<Record<string, unknown>> } })
+        .operation;
+      cb({ result: op?.updates ? [op.updates[0]] : [] });
+    }) as SocketEmitMock);
+    if (opts.connected !== false) {
+      (client as unknown as { socket: { connected: boolean; emit: SocketEmitMock } }).socket = {
+        connected: true,
+        emit,
+      };
+    }
+    return { client, emit };
+  };
+
+  it('updateCombat emits a Combat update with turn/round and no parentUuid', async () => {
+    const { client, emit } = buildClient({});
+    await client.updateCombat(COMBAT_ID, { turn: 2, round: 3 });
+    const [event, body] = emit.mock.calls[0] as unknown[] as [string, Record<string, unknown>];
+    expect(event).toBe('modifyDocument');
+    expect(body).toMatchObject({
+      type: 'Combat',
+      action: 'update',
+      operation: { updates: [{ _id: COMBAT_ID, turn: 2, round: 3 }] },
+    });
+    expect((body.operation as Record<string, unknown>).parentUuid).toBeUndefined();
+  });
+
+  it('endCombat emits a Combat delete carrying ids', async () => {
+    const { client, emit } = buildClient({});
+    await client.endCombat(COMBAT_ID);
+    const [, body] = emit.mock.calls[0] as unknown[] as [string, Record<string, unknown>];
+    expect(body).toMatchObject({
+      type: 'Combat',
+      action: 'delete',
+      operation: { ids: [COMBAT_ID] },
+    });
+  });
+
+  it('setCombatantInitiative emits a Combatant update with parentUuid Combat.<id>', async () => {
+    const { client, emit } = buildClient({});
+    await client.setCombatantInitiative(COMBAT_ID, COMBATANT_ID, 12);
+    const [, body] = emit.mock.calls[0] as unknown[] as [string, Record<string, unknown>];
+    expect(body).toMatchObject({
+      type: 'Combatant',
+      action: 'update',
+      operation: {
+        updates: [{ _id: COMBATANT_ID, initiative: 12 }],
+        parentUuid: `Combat.${COMBAT_ID}`,
+      },
+    });
+  });
+
+  it('rejects writes when FOUNDRY_WRITE_ENABLED is false', async () => {
+    const { client } = buildClient({ writeEnabled: false });
+    await expect(client.updateCombat(COMBAT_ID, { turn: 1 })).rejects.toThrow(
+      /FOUNDRY_WRITE_ENABLED/,
+    );
+  });
+
+  it('rejects writes when the Socket.IO connection is not active', async () => {
+    const { client } = buildClient({ writeEnabled: true, connected: false });
+    await expect(client.endCombat(COMBAT_ID)).rejects.toThrow(/Socket\.IO connection/);
+  });
+
+  it('rejects a malformed combat id', async () => {
+    const { client } = buildClient({});
+    await expect(client.updateCombat('short', { turn: 1 })).rejects.toThrow(/Invalid combatId/);
+  });
+
+  it('rejects a malformed combatant id', async () => {
+    const { client } = buildClient({});
+    await expect(client.setCombatantInitiative(COMBAT_ID, 'short', 5)).rejects.toThrow(
+      /Invalid combatantId/,
+    );
+  });
+
+  it('rejects a non-finite initiative at the client', async () => {
+    const { client } = buildClient({});
+    await expect(
+      client.setCombatantInitiative(COMBAT_ID, COMBATANT_ID, Number.POSITIVE_INFINITY),
+    ).rejects.toThrow(/Invalid initiative/);
+  });
+});

--- a/src/tools/handlers/combat-mutations.ts
+++ b/src/tools/handlers/combat-mutations.ts
@@ -1,0 +1,143 @@
+/**
+ * @fileoverview Combat control mutation tool handlers (FR-018)
+ *
+ * Provides GM-gated combat-control tools that operate on the *active* combat:
+ * advancing the turn, ending the encounter, and setting a combatant's
+ * initiative. All are WRITE operations — they require FOUNDRY_WRITE_ENABLED=true
+ * and an active Socket.IO connection (mutations use the core `modifyDocument`
+ * protocol), and the connected user needs GM/owner permission.
+ */
+
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import type { FoundryClient } from '../../foundry/client.js';
+import type { WorldCombat } from '../../foundry/types.js';
+import { withToolError } from './utils.js';
+
+/**
+ * Computes the next `{ turn, round }` for an active combat.
+ *
+ * Advances to the next combatant in order; wrapping past the last combatant
+ * rolls over to turn 0 of the next round.
+ *
+ * Known limitation: this does NOT skip `defeated` combatants the way Foundry's
+ * `Combat#nextTurn` does with `skipDefeated`. Turn order is treated as the raw
+ * combatant array order. Defeated-skipping is deferred to a follow-up.
+ *
+ * @throws if the combat has no combatants (cannot advance an empty encounter).
+ */
+export function computeNextTurn(combat: WorldCombat): { turn: number; round: number } {
+  const n = combat.combatants.length;
+  if (n === 0) {
+    throw new Error('Cannot advance turn: active combat has no combatants');
+  }
+  const cur = combat.turn ?? 0;
+  const next = cur + 1;
+  if (next >= n) {
+    return { turn: 0, round: combat.round + 1 };
+  }
+  return { turn: next, round: combat.round };
+}
+
+/**
+ * Advances the active combat to the next turn (FR-018).
+ */
+export async function handleNextTurn(_args: Record<string, unknown>, foundryClient: FoundryClient) {
+  const combat = foundryClient.getCombatState();
+  if (!combat) {
+    throw new McpError(ErrorCode.InvalidRequest, 'No active combat to advance.');
+  }
+
+  return withToolError('advance combat turn', async () => {
+    const { turn, round } = computeNextTurn(combat);
+    await foundryClient.updateCombat(combat._id, { turn, round });
+
+    const current = combat.combatants[turn];
+    const currentName = current ? current.name : 'unknown';
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `⚔️ **Combat Turn Advanced**
+**Round:** ${round}
+**Turn:** ${turn + 1} of ${combat.combatants.length}
+**Now acting:** ${currentName}`,
+        },
+      ],
+    };
+  });
+}
+
+/**
+ * Ends (deletes) the active combat encounter (FR-018).
+ */
+export async function handleEndCombat(
+  _args: Record<string, unknown>,
+  foundryClient: FoundryClient,
+) {
+  const combat = foundryClient.getCombatState();
+  if (!combat) {
+    throw new McpError(ErrorCode.InvalidRequest, 'No active combat to end.');
+  }
+
+  return withToolError('end combat', async () => {
+    await foundryClient.endCombat(combat._id);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `⚔️ **Combat Ended**
+**Encounter:** ${combat._id}
+The active combat encounter has been removed.`,
+        },
+      ],
+    };
+  });
+}
+
+/**
+ * Sets a combatant's initiative in the active combat (FR-018).
+ *
+ * `combatId` defaults to the active combat when omitted.
+ */
+export async function handleSetInitiative(
+  args: { combatantId: string; initiative: number; combatId?: string },
+  foundryClient: FoundryClient,
+) {
+  const { combatantId, initiative, combatId } = args;
+
+  if (!combatantId || typeof combatantId !== 'string') {
+    throw new McpError(ErrorCode.InvalidParams, 'combatantId is required and must be a string');
+  }
+  if (typeof initiative !== 'number' || !Number.isFinite(initiative)) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      'initiative is required and must be a finite number',
+    );
+  }
+
+  const resolvedCombatId = combatId ?? foundryClient.getCombatState()?._id;
+  if (!resolvedCombatId) {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      'No active combat and no combatId provided; cannot set initiative.',
+    );
+  }
+
+  return withToolError('set combatant initiative', async () => {
+    await foundryClient.setCombatantInitiative(resolvedCombatId, combatantId, initiative);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `⚔️ **Initiative Set**
+**Combat:** ${resolvedCombatId}
+**Combatant:** ${combatantId}
+**Initiative:** ${initiative}`,
+        },
+      ],
+    };
+  });
+}

--- a/src/tools/router.ts
+++ b/src/tools/router.ts
@@ -13,6 +13,11 @@ import { handleUpdateActorAttribute } from './handlers/actor-mutations.js';
 import { handleGetActorDetails, handleSearchActors } from './handlers/actors.js';
 import { handleGetChatMessages } from './handlers/chat.js';
 import { handleGetCombatState } from './handlers/combat.js';
+import {
+  handleEndCombat,
+  handleNextTurn,
+  handleSetInitiative,
+} from './handlers/combat-mutations.js';
 import { handleSearchCompendium } from './handlers/compendium.js';
 import {
   handleDiagnoseErrors,
@@ -171,6 +176,23 @@ export async function routeToolRequest(
     // Combat tools
     case 'get_combat_state':
       return handleGetCombatState(args, foundryClient);
+
+    // Combat mutation tools (FR-018, WRITE — require FOUNDRY_WRITE_ENABLED)
+    case 'next_turn':
+      return handleNextTurn(args, foundryClient);
+    case 'end_combat':
+      return handleEndCombat(args, foundryClient);
+    case 'set_initiative':
+      if (!('combatantId' in args) || typeof args.combatantId !== 'string') {
+        throw new Error('Missing required parameter: combatantId');
+      }
+      if (!('initiative' in args) || typeof args.initiative !== 'number') {
+        throw new Error('Missing required parameter: initiative');
+      }
+      return handleSetInitiative(
+        args as { combatantId: string; initiative: number; combatId?: string },
+        foundryClient,
+      );
 
     // Chat tools
     case 'get_chat_messages':

--- a/tests/integration/combat.integration.test.ts
+++ b/tests/integration/combat.integration.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Integration tests for the combat control write tools (FR-018):
+ * set_initiative and next_turn over the FoundryVTT `modifyDocument` Socket.IO
+ * protocol.
+ *
+ * Unlike the handler unit tests (which mock the client), these drive real
+ * game-state mutations against a live world, so they require:
+ *   - a launched world with an *active* combat that has at least one combatant,
+ *     and
+ *   - the connected user to hold GM/owner permission (writes are GM-gated).
+ *
+ * When no active combat / combatant is present — e.g. the fresh, world-less CI
+ * instance (issue #140) — the suite skips rather than failing, matching the
+ * live-world precondition shared by the other integration specs.
+ *
+ * Reversible mutations are reverted: initiative is restored to its original
+ * value and the turn/round pointers are restored, leaving world state
+ * unchanged. end_combat is irreversible (it deletes the encounter) and is
+ * therefore covered by unit tests ONLY — we do not run a destructive live
+ * delete against the shared harness world.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { FoundryClient } from '../../src/foundry/client.js';
+import type { WorldCombat } from '../../src/foundry/types.js';
+import { createConnectedClient } from './setup.js';
+
+describe('Combat write operations', () => {
+  let client: FoundryClient;
+  let combat: WorldCombat | null = null;
+
+  beforeAll(async () => {
+    // Writes are opt-in (FOUNDRY_WRITE_ENABLED) and require the Socket.IO
+    // transport; the shared helper connects with username/password.
+    client = await createConnectedClient({ writeEnabled: true });
+
+    // The active combat doubles as the skip gate: a world-less instance, or a
+    // world with no active encounter, yields null and every test skips.
+    const active = client.getCombatState();
+    if (active && active.combatants.length > 0) {
+      combat = active;
+    }
+  });
+
+  afterAll(async () => {
+    if (client) {
+      await client.disconnect();
+    }
+  });
+
+  it('set_initiative sets a combatant initiative then restores it', (ctx) => {
+    if (!combat) {
+      return ctx.skip();
+    }
+    return (async () => {
+      const combatant = combat!.combatants[0];
+      const original = combatant.initiative;
+
+      await client.setCombatantInitiative(combat!._id, combatant._id, 99);
+
+      // Restore the original value (null → not rolled; only restore a number).
+      if (typeof original === 'number') {
+        await client.setCombatantInitiative(combat!._id, combatant._id, original);
+      }
+
+      // No assertion on read-back: worldData is a stale snapshot after a write.
+      // A resolved call without error is the round-trip success signal here.
+      expect(true).toBe(true);
+    })();
+  });
+
+  it('next_turn advances the active combat then restores turn/round', (ctx) => {
+    if (!combat) {
+      return ctx.skip();
+    }
+    return (async () => {
+      const originalTurn = combat!.turn ?? 0;
+      const originalRound = combat!.round;
+
+      const n = combat!.combatants.length;
+      const next = originalTurn + 1;
+      const advanced =
+        next >= n ? { turn: 0, round: originalRound + 1 } : { turn: next, round: originalRound };
+
+      await client.updateCombat(combat!._id, advanced);
+
+      // Restore the original turn/round so world state is left unchanged.
+      await client.updateCombat(combat!._id, { turn: originalTurn, round: originalRound });
+
+      expect(true).toBe(true);
+    })();
+  });
+});


### PR DESCRIPTION
## Summary

FR-018 Phase 1a — three GM-gated combat-control MCP tools operating on the **active** combat, built on the existing Socket.IO `modifyDocument` write protocol (verified against the harness-pinned **FoundryVTT 13.348** `client-backend.mjs` source). Disabled by default; require `FOUNDRY_WRITE_ENABLED=true` and an active Socket.IO session with GM/owner permission.

- `next_turn` — advance the active combat (wraps to next round past the last combatant)
- `end_combat` — delete the active combat encounter
- `set_initiative` — set a combatant's initiative (`combatId` defaults to active)

Moves FR-018 `planned → partial` (3/4 tools) and FR-021 (character-sheet editing) `planned → complete` (delivered earlier by actor/item mutations).

## Implementation

- **client** (`src/foundry/client.ts`): `updateCombat` / `endCombat` / `setCombatantInitiative` — `Combat` top-level update+delete; `Combatant` embedded update with `parentUuid: "Combat.<id>"`.
- **pure helper** `computeNextTurn` (`src/tools/handlers/combat-mutations.ts`) — wraps to next round; does **not** yet skip defeated combatants.
- **handlers / definitions / router** — unconditional tool registration; runtime gate via `assertWriteable()`.

## Tests

- Unit (`combat-mutations.test.ts`, 22 tests): handler happy / no-combat McpError / write-disabled guard / validation paths, plus client-level `modifyDocument` wire-shape assertions (Combat update/delete, Combatant `parentUuid`).
- Gated live integration (`tests/integration/combat.integration.test.ts`): `set_initiative` + `next_turn` round-trip+restore using the skip/revert idiom. `end_combat` is destructive → unit-only.
- `just qa` green (biome + tsc + 273 unit tests, no regressions). Live integration skips cleanly without a licensed test instance (CI gap #140); coverage tooling `@vitest/coverage-v8` is not installed locally.

## Deferred (linked issues)

- `start_combat` (highest-risk — creates Combat + Combatant docs): #172
- `next_turn` skipDefeated refinement: #173
- FR-019 token manipulation tools: #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)