### PR TITLE
style(tests): fix biome lint failures blocking Test CI

### DIFF
--- a/src/foundry/__tests__/client.test.ts
+++ b/src/foundry/__tests__/client.test.ts
@@ -270,7 +270,7 @@ describe('FoundryClient', () => {
         .mockRejectedValueOnce(build4xxError(503))
         .mockResolvedValueOnce({ data: { actors: [] } });
 
-      const result = await client.searchActors({ query: 'x' });
+      await client.searchActors({ query: 'x' });
       expect(mockAxiosInstance.get).toHaveBeenCalledTimes(2);
     });
 

--- a/src/tools/handlers/__tests__/actors.test.ts
+++ b/src/tools/handlers/__tests__/actors.test.ts
@@ -31,7 +31,13 @@ function buildActor(overrides: Partial<FoundryActor> = {}): FoundryActor {
 describe('handleSearchActors', () => {
   it('returns a formatted list of actors on happy path', async () => {
     const actors: FoundryActor[] = [
-      buildActor({ _id: 'a1', name: 'Aragorn', type: 'character', level: 5, hp: { value: 30, max: 40 } }),
+      buildActor({
+        _id: 'a1',
+        name: 'Aragorn',
+        type: 'character',
+        level: 5,
+        hp: { value: 30, max: 40 },
+      }),
       buildActor({ _id: 'a2', name: 'Goblin', type: 'npc', level: 1, hp: { value: 7, max: 7 } }),
     ];
     const searchResult: ActorSearchResult = { actors, total: 2, page: 1, limit: 10 };
@@ -88,7 +94,9 @@ describe('handleSearchActors', () => {
   });
 
   it('falls back to "Unknown" when level and hp are missing', async () => {
-    const actors: FoundryActor[] = [buildActor({ name: 'Mystery', level: undefined, hp: undefined })];
+    const actors: FoundryActor[] = [
+      buildActor({ name: 'Mystery', level: undefined, hp: undefined }),
+    ];
     const searchResult: ActorSearchResult = { actors, total: 1, page: 1, limit: 10 };
     const client = {
       searchActors: vi.fn().mockResolvedValue(searchResult),

--- a/src/tools/handlers/__tests__/generation.test.ts
+++ b/src/tools/handlers/__tests__/generation.test.ts
@@ -7,11 +7,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { FoundryClient } from '../../../foundry/client.js';
-import {
-  handleGenerateLoot,
-  handleGenerateNPC,
-  handleLookupRule,
-} from '../generation.js';
+import { handleGenerateLoot, handleGenerateNPC, handleLookupRule } from '../generation.js';
 
 // The handlers do not call any FoundryClient methods, so an empty stub suffices.
 const stubClient = {} as unknown as FoundryClient;

--- a/src/tools/handlers/__tests__/items.test.ts
+++ b/src/tools/handlers/__tests__/items.test.ts
@@ -21,9 +21,12 @@ interface MockSearchParams {
   limit: number;
 }
 
-function mockFoundryClient(
-  result: { items: MockItem[]; total: number; page: number; limit: number },
-): { client: FoundryClient; calls: { params: MockSearchParams[] } } {
+function mockFoundryClient(result: {
+  items: MockItem[];
+  total: number;
+  page: number;
+  limit: number;
+}): { client: FoundryClient; calls: { params: MockSearchParams[] } } {
   const calls = { params: [] as MockSearchParams[] };
   const client = {
     searchItems: vi.fn(async (params: MockSearchParams) => {

--- a/src/tools/handlers/__tests__/search_logs.test.ts
+++ b/src/tools/handlers/__tests__/search_logs.test.ts
@@ -73,9 +73,9 @@ describe('handleSearchLogs', () => {
 
     it('throws McpError when query is empty string', async () => {
       const client = mockClient([]);
-      await expect(
-        handleSearchLogs({ query: '' } as { query: string }, client),
-      ).rejects.toThrow(/Query is required/);
+      await expect(handleSearchLogs({ query: '' } as { query: string }, client)).rejects.toThrow(
+        /Query is required/,
+      );
     });
 
     it('throws McpError when query is not a string', async () => {

--- a/src/tools/handlers/__tests__/world.test.ts
+++ b/src/tools/handlers/__tests__/world.test.ts
@@ -12,11 +12,7 @@ import type {
   WorldJournal,
   WorldScene,
 } from '../../../foundry/types.js';
-import {
-  handleGetWorldSummary,
-  handleRefreshWorldData,
-  handleSearchWorld,
-} from '../world.js';
+import { handleGetWorldSummary, handleRefreshWorldData, handleSearchWorld } from '../world.js';
 
 function getText(result: { content: Array<{ type: string; text: string }> }): string {
   return result.content[0]?.text ?? '';


### PR DESCRIPTION
## What

The **Test** workflow on `main` fails at the `Run linter` step (`bun run lint` → `biome check src`) with 6 errors:

- **5 formatting violations** across test files (multi-line call/import collapsing)
- **1 `noUnusedVariables` error** — an unused `result` binding in `client.test.ts` (the test only asserts call count)

## Why

`main` CI is red; this is one of three independent root causes. Formatting + the dead binding are a single lint concern, fixed together here.

## How

- `biome check --write src` → reformats `actors`, `generation`, `items`, `search_logs`, `world` test files
- Drop the unused `const result =` in the 503-retry test (asserts `toHaveBeenCalledTimes(2)` only)

## Verification (local, full Test job)

- `biome check src` → 0 errors (11 pre-existing `noExplicitAny` warnings remain, non-blocking)
- `tsc --noEmit` clean · `bun run build` OK
- `bun run test` → **273 passed**
- `bun run smoke` + `bun run smoke:pack` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)