### PR TITLE
ci(docs): migrate documentation workflows from npm to bun

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,19 +34,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '18'
-          cache: 'npm'
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: npm ci
+        run: bun install --frozen-lockfile
 
       - name: Generate documentation
         run: |
           # Generate TypeDoc documentation with error checking disabled for problematic files
-          npx typedoc src/foundry/client.ts src/foundry/types.ts src/config/index.ts src/utils/logger.ts \
+          bunx typedoc src/foundry/client.ts src/foundry/types.ts src/config/index.ts src/utils/logger.ts \
             --out docs \
             --name "FoundryVTT MCP Server Documentation" \
             --readme README.md \

--- a/.github/workflows/setup-docs.yml
+++ b/.github/workflows/setup-docs.yml
@@ -20,18 +20,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '18'
-          cache: 'npm'
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: npm ci
+        run: bun install --frozen-lockfile
 
       - name: Generate initial documentation
         run: |
-          npx typedoc src/foundry/client.ts src/foundry/types.ts src/config/index.ts src/utils/logger.ts \
+          bunx typedoc src/foundry/client.ts src/foundry/types.ts src/config/index.ts src/utils/logger.ts \
             --out docs \
             --name "FoundryVTT MCP Server Documentation" \
             --readme README.md \

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -24,19 +24,16 @@ jobs:
           # Use a personal access token to allow pushing back to the repo
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '18'
-          cache: 'npm'
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
 
       - name: Install dependencies
-        run: npm ci
+        run: bun install --frozen-lockfile
 
       - name: Generate documentation
         run: |
           # Generate TypeDoc documentation with error checking disabled for problematic files
-          npx typedoc src/foundry/client.ts src/foundry/types.ts src/config/index.ts src/utils/logger.ts \
+          bunx typedoc src/foundry/client.ts src/foundry/types.ts src/config/index.ts src/utils/logger.ts \
             --out docs \
             --name "FoundryVTT MCP Server Documentation" \
             --readme README.md \


### PR DESCRIPTION
## What

Migrate the three documentation workflows — `docs.yml` (Generate and Deploy Documentation), `update-docs.yml` (Update Documentation), and `setup-docs.yml` (Setup Documentation Site) — from npm to bun.

## Why

All three used `actions/setup-node@v6` with `cache: 'npm'` and `npm ci`, but the repo is **bun-only** (`bun.lock`, no `package-lock.json`). setup-node's npm cache resolution failed:

```
##[error]Dependencies lock file is not found ... Supported file patterns: package-lock.json, npm-shrinkwrap.json, yarn.lock
```

This broke **Generate and Deploy Documentation** and **Update Documentation** on every push to `main` — two of the red checks.

## How

Per workflow:
- `actions/setup-node@v6` (`node-version: 18`, `cache: npm`) → `oven-sh/setup-bun@v2`
- `npm ci` → `bun install --frozen-lockfile`
- `npx typedoc …` → `bunx typedoc …`

This matches the already-bun `test.yml` and `security.yml`. No other lines touched (pre-existing shellcheck style findings in the commit/summary `run:` blocks are out of scope).

## Verification

- Ran the exact typedoc command locally via `bunx typedoc …` → **0 errors, 2 benign warnings**, HTML generated under `docs/`.
- `bun install --frozen-lockfile` resolves against the committed `bun.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)