### PR TITLE
docs(changelog): remove stale manual Unreleased block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,5 @@
 # Changelog
 
-## Unreleased
-
-### Breaking Changes
-
-* **architecture:** extracted foundry-local-rest-api module to standalone repository
-  - Moved `foundry-local-rest-api/` directory to https://github.com/laurigates/foundryvtt-local-rest-api
-  - Removed module build infrastructure (process-template.cjs, build-foundry-module.yml)
-  - Removed related E2E tests (rest-api-module.spec.ts, issue-7-json-parsing.spec.ts, module-settings.spec.ts)
-  - This change improves repository focus and allows independent versioning of the FoundryVTT module
-
 ## [1.2.0](https://github.com/laurigates/foundryvtt-mcp/compare/foundryvtt-mcp-v1.1.0...foundryvtt-mcp-v1.2.0) (2026-06-20)
 
 


### PR DESCRIPTION
## Summary

Closes the last actionable code follow-up from #164: cleaning the manual `## Unreleased` block at the top of `CHANGELOG.md`.

The hand-added block described the `foundry-local-rest-api` module extraction — a breaking change that was **already captured and released in the `## [1.0.0]` changelog entry** (which carries the `⚠ BREAKING CHANGES` note about the module move). Because release-please does not manage that manual section, the block rode along at the top of the changelog through the `1.0.1`, `1.1.0`, and `1.2.0` releases.

This removes it so it no longer conflicts with the release-please-generated changelog.

## Status of #164 follow-ups

- [ ] **Delete the orphaned `RELEASE_PLEASE_TOKEN` secret** — manual repo-admin action (`gh secret delete RELEASE_PLEASE_TOKEN -R laurigates/foundryvtt-mcp`); cannot be done from this session. The `release-please.yml` workflow already uses the gitops-managed App token (`RELEASE_PLEASE_APP_ID` / `RELEASE_PLEASE_PRIVATE_KEY`) and no longer references the PAT, so the secret is safe to delete.
- [x] **Confirm the Release Please App is installed** — already verified in the issue.
- [x] **Verify the next release is correct** — the migration succeeded and releases have since progressed normally (`1.0.1` → `1.1.0` → `1.2.0`, current `package.json` at `1.2.0`). The `2.0.0` expectation no longer applies: the rest-api extraction was released as part of `1.0.0`, not pending, so subsequent minor/patch bumps are correct.
- [x] **Clean the manual `## Unreleased` block** — done in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WFCaB9zf1Aqg7bMwWCbuMv)_