### PR TITLE
docs(examples): fix inverted transport guidance in client configs

### DIFF
--- a/examples/mcp-client-configs.md
+++ b/examples/mcp-client-configs.md
@@ -21,14 +21,18 @@ Add this to your Claude Desktop MCP settings file:
       "args": ["/path/to/foundryvtt-mcp/dist/index.js"],
       "env": {
         "FOUNDRY_URL": "http://localhost:30000",
-        "USE_REST_MODULE": "true",
-        "FOUNDRY_API_KEY": "your_api_key_here",
+        "FOUNDRY_USERNAME": "your_username",
+        "FOUNDRY_PASSWORD": "your_password",
         "LOG_LEVEL": "info"
       }
     }
   }
 }
 ```
+
+> The server connects to FoundryVTT directly over **Socket.IO** using a world
+> user account — no custom module required. Setting `FOUNDRY_API_KEY` additionally
+> enables the optional, read-only REST diagnostics tools.
 
 ### Alternative: Using .env file
 
@@ -151,18 +155,17 @@ if __name__ == "__main__":
 When configuring your MCP client, you can set these environment variables:
 
 ```bash
-# Required
+# Required — Socket.IO connection (the default and primary transport)
 FOUNDRY_URL=http://localhost:30000
-
-# Connection Method (choose one approach)
-# Option 1: REST API Module (recommended)
-USE_REST_MODULE=true
-FOUNDRY_API_KEY=your_api_key_here
-
-# Option 2: Basic WebSocket (limited functionality)
-USE_REST_MODULE=false
 FOUNDRY_USERNAME=your_username
 FOUNDRY_PASSWORD=your_password
+
+# Optional — enables the read-only REST API diagnostics tools.
+# When set, the server uses REST API mode instead of Socket.IO.
+FOUNDRY_API_KEY=your_api_key_here
+
+# Optional — enables game-state mutations (write tools). Default: false.
+FOUNDRY_WRITE_ENABLED=true
 
 # Optional
 LOG_LEVEL=info
@@ -227,9 +230,9 @@ Once connected, try these prompts with your AI assistant:
    - Try `npm run test-connection` to diagnose
 
 3. **"Empty results" or limited functionality**
-   - Install the FoundryVTT REST API module for full features
-   - Set `USE_REST_MODULE=true` and configure API key
-   - Some features work without REST module but with limitations
+   - Ensure a **world is loaded** in FoundryVTT (the server needs an active world, not the setup screen)
+   - Verify the user account has sufficient permissions (Assistant GM or higher)
+   - The optional REST API module / `FOUNDRY_API_KEY` adds diagnostics tools, but is not required for core data access
 
 4. **Permission or authentication errors**
    - Check FoundryVTT user permissions


### PR DESCRIPTION
## Summary

`examples/mcp-client-configs.md` documented the connection transports **backwards** relative to how the server actually behaves:

- It presented the REST API module as the *"recommended"* connection method and Socket.IO as *"Basic WebSocket (limited functionality)"*.
- In reality, **Socket.IO (username/password) is the default and primary transport** — `src/config/index.ts` selects REST mode *only* when `FOUNDRY_API_KEY` is set, and the README/SETUP_GUIDE already describe Socket.IO as primary with REST as optional, read-only diagnostics.

This is a doc-only fix; no code changes.

## Changes

- Claude Desktop example now uses `FOUNDRY_USERNAME`/`FOUNDRY_PASSWORD` (Socket.IO) instead of `USE_REST_MODULE`/`FOUNDRY_API_KEY`, with a note that the REST key is optional.
- Env-var reference reordered: Socket.IO required vars first, `FOUNDRY_API_KEY` as optional diagnostics, `FOUNDRY_WRITE_ENABLED` added.
- Removed the **dead `USE_REST_MODULE` variable** entirely — it is not read by `src/config/index.ts` (transport is chosen purely on `FOUNDRY_API_KEY` presence); it lingered only in this doc and one config test.
- Reframed the "empty results" troubleshooting away from "install the REST module" toward the real causes (no world loaded, insufficient user permissions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)