### PR TITLE
feat(combat): add start_combat and skip defeated combatants in next_turn

### DIFF
--- a/docs/prps/implement-write-operations.md
+++ b/docs/prps/implement-write-operations.md
@@ -17,8 +17,8 @@ Add write operations to foundryvtt-mcp, starting with combat management (FR-018)
 | Actor attribute mutation (FR-021) | ✅ Shipped — `update_actor_attributes` (#143) |
 | Actor item CRUD (FR-021) | ✅ Shipped — `create_actor_item` / `update_actor_item` / `delete_actor_item` (#142, #159) |
 | Combat write — `next_turn`, `end_combat`, `set_initiative` (FR-018) | ✅ Shipped — Phase 1a, this PRP |
-| Combat write — `start_combat` (FR-018) | ⏳ Deferred — [#172](https://github.com/laurigates/foundryvtt-mcp/issues/172) |
-| `next_turn` skipDefeated refinement | ⏳ Deferred — [#173](https://github.com/laurigates/foundryvtt-mcp/issues/173) |
+| Combat write — `start_combat` (FR-018) | ✅ Shipped — [#172](https://github.com/laurigates/foundryvtt-mcp/issues/172) |
+| `next_turn` skipDefeated refinement | ✅ Shipped — [#173](https://github.com/laurigates/foundryvtt-mcp/issues/173) |
 | Token manipulation — `move_token`, `apply_status_effect` (FR-019) | ✅ Shipped — [#174](https://github.com/laurigates/foundryvtt-mcp/issues/174) |
 | Token manipulation — `update_token` (name/visibility/disposition) (FR-019) | ⏳ Deferred |
 
@@ -42,12 +42,15 @@ for embedded documents (e.g. `Combatant` → `Combat.<combatId>`). See
 
 Three GM-gated tools operating on the **active** combat, disabled by default:
 
-- `next_turn` — advance turn; wraps to next round past the last combatant
-  (does not yet skip defeated combatants — [#173](https://github.com/laurigates/foundryvtt-mcp/issues/173))
+- `next_turn` — advance turn; wraps to next round past the last combatant.
+  Skips `defeated` combatants when the `skipDefeated` arg is set (or the combat's
+  `settings.skipDefeated`); see [#173](https://github.com/laurigates/foundryvtt-mcp/issues/173)
 - `end_combat` — delete the active combat encounter
 - `set_initiative` — set a combatant's initiative (`combatId` defaults to active)
+- `start_combat` — create a Combat and seed Combatants from `tokenIds` (or the
+  active scene's tokens); see [#172](https://github.com/laurigates/foundryvtt-mcp/issues/172)
 
-Client methods: `updateCombat`, `endCombat`, `setCombatantInitiative`
+Client methods: `updateCombat`, `endCombat`, `setCombatantInitiative`, `startCombat`
 (`src/foundry/client.ts`). Pure helper `computeNextTurn` and handlers in
 `src/tools/handlers/combat-mutations.ts`.
 
@@ -73,8 +76,8 @@ Client methods: `updateCombat`, `endCombat`, `setCombatantInitiative`
 
 ## Deferred (separate issues)
 
-- `start_combat` (FR-018, highest-risk — creates Combat + Combatant docs): [#172](https://github.com/laurigates/foundryvtt-mcp/issues/172)
-- `next_turn` skipDefeated refinement: [#173](https://github.com/laurigates/foundryvtt-mcp/issues/173)
+- `start_combat` (FR-018, highest-risk — creates Combat + Combatant docs): ✅ shipped via [#172](https://github.com/laurigates/foundryvtt-mcp/issues/172)
+- `next_turn` skipDefeated refinement: ✅ shipped via [#173](https://github.com/laurigates/foundryvtt-mcp/issues/173)
 - Token manipulation tools (FR-019 — `move_token`, `apply_status_effect`): ✅ shipped via [#174](https://github.com/laurigates/foundryvtt-mcp/issues/174). `update_token` (name/visibility/disposition) still deferred.
 
 ## Success Criteria

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -804,6 +804,57 @@ export class FoundryClient {
     return result[0];
   }
 
+  /**
+   * Starts a new combat encounter and seeds its combatants (FR-018, #172).
+   *
+   * Two-step `modifyDocument` flow:
+   *   1. Create the top-level `Combat` document (no `parentUuid`), activated on
+   *      the given scene, and read its `_id` from the response.
+   *   2. Create the embedded `Combatant` documents with
+   *      `parentUuid: "Combat.<combatId>"` (mirrors the Combatant→Combat embed
+   *      used by {@link setCombatantInitiative}).
+   *
+   * The create wire shape is verified against the v13.348 client source per
+   * `.claude/rules/foundry-write-protocol.md`; smoke-test one live round-trip
+   * when changing it.
+   *
+   * @param sceneId - 16-char alphanumeric Scene document id the combat runs on
+   * @param combatants - combatant seeds ({ tokenId, sceneId, actorId? })
+   * @returns the new combat id and the number of combatants created
+   */
+  async startCombat(
+    sceneId: string,
+    combatants: Array<{ tokenId: string; sceneId: string; actorId?: string | undefined }>,
+  ): Promise<{ combatId: string; combatantCount: number }> {
+    this.assertWriteable();
+    if (!FOUNDRY_ID_PATTERN.test(sceneId)) {
+      throw new Error(`Invalid sceneId format: ${sceneId}`);
+    }
+    for (const c of combatants) {
+      if (!FOUNDRY_ID_PATTERN.test(c.tokenId)) {
+        throw new Error(`Invalid tokenId format: ${c.tokenId}`);
+      }
+    }
+
+    const created = await this.modifyDocument('Combat', 'create', {
+      data: [{ scene: sceneId, active: true }],
+    });
+    const combat = created[0] as { _id?: string } | undefined;
+    const combatId = combat?._id;
+    if (!combatId) {
+      throw new Error('FoundryVTT did not return a Combat id after create');
+    }
+
+    if (combatants.length > 0) {
+      await this.modifyDocument('Combatant', 'create', {
+        data: combatants,
+        parentUuid: `Combat.${combatId}`,
+      });
+    }
+
+    return { combatId, combatantCount: combatants.length };
+  }
+
   // ==========================================================================
   // Token mutation methods (WRITE — Socket.IO modifyDocument, FR-019)
   // ==========================================================================

--- a/src/foundry/types.ts
+++ b/src/foundry/types.ts
@@ -859,6 +859,15 @@ export interface WorldCombat {
     defeated: boolean;
     flags?: Record<string, unknown>;
   }>;
+  /**
+   * Combat tracker settings. The core `skipDefeated` toggle lives in the
+   * `core.combatTrackerConfig` world setting and may not be present in every
+   * worldData snapshot, so it is optional here.
+   */
+  settings?: {
+    skipDefeated?: boolean;
+    resource?: string;
+  };
   flags?: Record<string, unknown>;
 }
 

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -487,11 +487,17 @@ export const combatMutationTools = [
     name: 'next_turn',
     description:
       'Advance the active combat to the next turn, wrapping to the next round after the last combatant. ' +
-      'Does not yet skip defeated combatants. ' +
+      'When skipDefeated is true, defeated combatants are skipped. ' +
       'Requires FOUNDRY_WRITE_ENABLED=true and an active Socket.IO connection.',
     inputSchema: {
       type: 'object',
-      properties: {},
+      properties: {
+        skipDefeated: {
+          type: 'boolean',
+          description:
+            "Skip combatants flagged as defeated when advancing. Defaults to the combat's skipDefeated setting, or false.",
+        },
+      },
     },
   },
   {
@@ -526,6 +532,29 @@ export const combatMutationTools = [
         },
       },
       required: ['combatantId', 'initiative'],
+    },
+  },
+  {
+    name: 'start_combat',
+    description:
+      'Start a new combat encounter, seeding combatants from tokens. ' +
+      'Provide explicit tokenIds, or omit them to seed every token on the scene. ' +
+      'Defaults to the active scene when sceneId is omitted. ' +
+      'Requires FOUNDRY_WRITE_ENABLED=true and an active Socket.IO connection (GM permission).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tokenIds: {
+          type: 'array',
+          items: { type: 'string' },
+          description:
+            'Optional list of Token document IDs to add as combatants. Defaults to all tokens on the scene.',
+        },
+        sceneId: {
+          type: 'string',
+          description: 'Optional Scene document ID; defaults to the active scene.',
+        },
+      },
     },
   },
 ];

--- a/src/tools/handlers/__tests__/combat-mutations.test.ts
+++ b/src/tools/handlers/__tests__/combat-mutations.test.ts
@@ -7,6 +7,7 @@ import {
   handleEndCombat,
   handleNextTurn,
   handleSetInitiative,
+  handleStartCombat,
 } from '../combat-mutations.js';
 
 const COMBAT_ID = 'cccccccccccccccc'; // 16 alphanumeric chars
@@ -46,20 +47,99 @@ describe('computeNextTurn', () => {
     const combat = makeCombat({ combatants: [] });
     expect(() => computeNextTurn(combat)).toThrow(/no combatants/);
   });
+
+  describe('skipDefeated', () => {
+    /** Combat with three combatants; defeated flags set via the `defeated` array. */
+    const makeTrio = (turn: number | null, round: number, defeated: [boolean, boolean, boolean]) =>
+      makeCombat({
+        turn,
+        round,
+        combatants: [
+          {
+            _id: 'aaaaaaaaaaaaaaaa',
+            name: 'A',
+            initiative: 20,
+            hidden: false,
+            defeated: defeated[0],
+          },
+          {
+            _id: 'bbbbbbbbbbbbbbbb',
+            name: 'B',
+            initiative: 15,
+            hidden: false,
+            defeated: defeated[1],
+          },
+          {
+            _id: 'gggggggggggggggg',
+            name: 'C',
+            initiative: 10,
+            hidden: false,
+            defeated: defeated[2],
+          },
+        ],
+      });
+
+    it('skips a defeated mid-list combatant', () => {
+      // turn 0 (A), B defeated -> should land on C (index 2)
+      const combat = makeTrio(0, 1, [false, true, false]);
+      expect(computeNextTurn(combat, true)).toEqual({ turn: 2, round: 1 });
+    });
+
+    it('does not skip when skipDefeated is false (regression guard)', () => {
+      const combat = makeTrio(0, 1, [false, true, false]);
+      expect(computeNextTurn(combat, false)).toEqual({ turn: 1, round: 1 });
+    });
+
+    it('wraps past a trailing defeated combatant into the next round', () => {
+      // turn 1 (B), C defeated -> no eligible left this round -> round 2, first alive (A)
+      const combat = makeTrio(1, 1, [false, false, true]);
+      expect(computeNextTurn(combat, true)).toEqual({ turn: 0, round: 2 });
+    });
+
+    it('advances to the lone survivor when all but one are defeated', () => {
+      // turn 0 (A), B and C defeated -> no eligible left this round -> round 2, first alive (A)
+      const combat = makeTrio(0, 1, [false, true, true]);
+      expect(computeNextTurn(combat, true)).toEqual({ turn: 0, round: 2 });
+    });
+
+    it('wraps the round to the next non-defeated combatant when the leader is defeated', () => {
+      // turn 2 (C), A defeated -> round 2, first alive is B (index 1)
+      const combat = makeTrio(2, 1, [true, false, false]);
+      expect(computeNextTurn(combat, true)).toEqual({ turn: 1, round: 2 });
+    });
+
+    it('falls back to turn 0 when every combatant is defeated', () => {
+      const combat = makeTrio(0, 1, [true, true, true]);
+      expect(computeNextTurn(combat, true)).toEqual({ turn: 0, round: 2 });
+    });
+  });
 });
 
 describe('Combat mutation handlers', () => {
   const createMockClient = (opts: {
     combat?: WorldCombat | null;
+    scenes?: Array<Record<string, unknown>>;
     updateCombat?: (id: string, patch: { turn?: number; round?: number }) => unknown;
     endCombat?: (id: string) => unknown;
     setInitiative?: (combatId: string, combatantId: string, initiative: number) => unknown;
+    startCombat?: (
+      sceneId: string,
+      combatants: Array<{ tokenId: string; sceneId: string; actorId?: string }>,
+    ) => unknown;
   }): FoundryClient =>
     ({
       getCombatState: vi.fn(() => opts.combat ?? null),
+      getScenes: vi.fn(() => opts.scenes ?? []),
       updateCombat: vi.fn(opts.updateCombat ?? (() => ({}))),
       endCombat: vi.fn(opts.endCombat ?? (() => undefined)),
       setCombatantInitiative: vi.fn(opts.setInitiative ?? (() => ({}))),
+      startCombat: vi.fn(
+        opts.startCombat ??
+          ((_sceneId: string, combatants: Array<unknown>) => ({
+            combatId: COMBAT_ID,
+            combatantCount: combatants.length,
+          })),
+      ),
     }) as unknown as FoundryClient;
 
   describe('handleNextTurn', () => {
@@ -91,6 +171,102 @@ describe('Combat mutation handlers', () => {
         },
       });
       await expect(handleNextTurn({}, client)).rejects.toThrow(/FOUNDRY_WRITE_ENABLED/);
+    });
+
+    it('skips a defeated combatant when skipDefeated arg is true', async () => {
+      const combat = makeCombat({
+        turn: 0,
+        round: 1,
+        combatants: [
+          { _id: COMBATANT_ID, name: 'Alice', initiative: 15, hidden: false, defeated: false },
+          { _id: 'eeeeeeeeeeeeeeee', name: 'Bob', initiative: 10, hidden: false, defeated: true },
+          { _id: 'ffffffffffffffff', name: 'Cara', initiative: 5, hidden: false, defeated: false },
+        ],
+      });
+      const client = createMockClient({ combat });
+      await handleNextTurn({ skipDefeated: true }, client);
+      // Bob (index 1) is defeated, so the turn advances to Cara (index 2).
+      expect(client.updateCombat).toHaveBeenCalledWith(COMBAT_ID, { turn: 2, round: 1 });
+    });
+
+    it('falls back to the combat skipDefeated setting when no arg is given', async () => {
+      const combat = makeCombat({
+        turn: 0,
+        round: 1,
+        settings: { skipDefeated: true },
+        combatants: [
+          { _id: COMBATANT_ID, name: 'Alice', initiative: 15, hidden: false, defeated: false },
+          { _id: 'eeeeeeeeeeeeeeee', name: 'Bob', initiative: 10, hidden: false, defeated: true },
+          { _id: 'ffffffffffffffff', name: 'Cara', initiative: 5, hidden: false, defeated: false },
+        ],
+      });
+      const client = createMockClient({ combat });
+      await handleNextTurn({}, client);
+      expect(client.updateCombat).toHaveBeenCalledWith(COMBAT_ID, { turn: 2, round: 1 });
+    });
+  });
+
+  describe('handleStartCombat', () => {
+    const SCENE_ID = 'ssssssssssssssss'.slice(0, 16);
+    const TOKEN_A = 'tokenaaaaaaaaaaa';
+    const TOKEN_B = 'tokenbbbbbbbbbbb';
+    const makeScene = (active: boolean, tokens: Array<Record<string, unknown>>) => ({
+      _id: SCENE_ID,
+      name: 'Battlefield',
+      active,
+      tokens,
+    });
+
+    it('seeds combatants from explicit tokenIds, resolving actorId from the token', async () => {
+      const startCombat = vi.fn(() => ({ combatId: COMBAT_ID, combatantCount: 1 }));
+      const client = createMockClient({
+        scenes: [makeScene(true, [{ _id: TOKEN_A, actorId: 'actoraaaaaaaaaaa' }])],
+        startCombat,
+      });
+      const result = await handleStartCombat({ tokenIds: [TOKEN_A] }, client);
+
+      expect(result.content[0].text).toContain('Combat Started');
+      expect(startCombat).toHaveBeenCalledWith(SCENE_ID, [
+        { tokenId: TOKEN_A, sceneId: SCENE_ID, actorId: 'actoraaaaaaaaaaa' },
+      ]);
+    });
+
+    it('defaults to every token on the active scene when tokenIds is omitted', async () => {
+      const startCombat = vi.fn(() => ({ combatId: COMBAT_ID, combatantCount: 2 }));
+      const client = createMockClient({
+        scenes: [
+          makeScene(true, [{ _id: TOKEN_A, actorId: 'actoraaaaaaaaaaa' }, { _id: TOKEN_B }]),
+        ],
+        startCombat,
+      });
+      await handleStartCombat({}, client);
+
+      expect(startCombat).toHaveBeenCalledWith(SCENE_ID, [
+        { tokenId: TOKEN_A, sceneId: SCENE_ID, actorId: 'actoraaaaaaaaaaa' },
+        { tokenId: TOKEN_B, sceneId: SCENE_ID, actorId: undefined },
+      ]);
+    });
+
+    it('honours an explicit sceneId', async () => {
+      const startCombat = vi.fn(() => ({ combatId: COMBAT_ID, combatantCount: 0 }));
+      const client = createMockClient({
+        scenes: [makeScene(false, []), { _id: 'othersssssssssss', name: 'Other', active: true }],
+        startCombat,
+      });
+      await handleStartCombat({ sceneId: SCENE_ID }, client);
+      expect(startCombat).toHaveBeenCalledWith(SCENE_ID, []);
+    });
+
+    it('raises McpError when no scene can be resolved', async () => {
+      const client = createMockClient({ scenes: [] });
+      await expect(handleStartCombat({}, client)).rejects.toThrow(McpError);
+      expect(client.startCombat).not.toHaveBeenCalled();
+    });
+
+    it('raises McpError when a requested token is not on the scene', async () => {
+      const client = createMockClient({ scenes: [makeScene(true, [{ _id: TOKEN_A }])] });
+      await expect(handleStartCombat({ tokenIds: [TOKEN_B] }, client)).rejects.toThrow(McpError);
+      expect(client.startCombat).not.toHaveBeenCalled();
     });
   });
 
@@ -172,9 +348,22 @@ describe('FoundryClient combat mutations', () => {
       writeEnabled: opts.writeEnabled ?? true,
     });
     const emit = vi.fn(((_event, payload, cb) => {
-      const op = (payload as { operation?: { updates?: Array<Record<string, unknown>> } })
-        .operation;
-      cb({ result: op?.updates ? [op.updates[0]] : [] });
+      const op = (
+        payload as {
+          operation?: {
+            updates?: Array<Record<string, unknown>>;
+            data?: Array<Record<string, unknown>>;
+          };
+        }
+      ).operation;
+      if (op?.updates) {
+        cb({ result: [op.updates[0]] });
+      } else if (op?.data) {
+        // Echo created docs, stamping a Combat id so startCombat can chain.
+        cb({ result: op.data.map((d) => ({ _id: COMBAT_ID, ...d })) });
+      } else {
+        cb({ result: [] });
+      }
     }) as SocketEmitMock);
     if (opts.connected !== false) {
       (client as unknown as { socket: { connected: boolean; emit: SocketEmitMock } }).socket = {
@@ -221,6 +410,63 @@ describe('FoundryClient combat mutations', () => {
         parentUuid: `Combat.${COMBAT_ID}`,
       },
     });
+  });
+
+  it('startCombat creates a Combat then embedded Combatants with parentUuid', async () => {
+    const SCENE_ID = 'sceneididididid1';
+    const TOKEN_ID = 'tokenididididid1';
+    const { client, emit } = buildClient({});
+    const result = await client.startCombat(SCENE_ID, [
+      { tokenId: TOKEN_ID, sceneId: SCENE_ID, actorId: 'actorididididid1' },
+    ]);
+
+    expect(result).toEqual({ combatId: COMBAT_ID, combatantCount: 1 });
+    expect(emit).toHaveBeenCalledTimes(2);
+
+    const [, combatBody] = emit.mock.calls[0] as unknown[] as [string, Record<string, unknown>];
+    expect(combatBody).toMatchObject({
+      type: 'Combat',
+      action: 'create',
+      operation: { data: [{ scene: SCENE_ID, active: true }] },
+    });
+    expect((combatBody.operation as Record<string, unknown>).parentUuid).toBeUndefined();
+
+    const [, combatantBody] = emit.mock.calls[1] as unknown[] as [string, Record<string, unknown>];
+    expect(combatantBody).toMatchObject({
+      type: 'Combatant',
+      action: 'create',
+      operation: {
+        data: [{ tokenId: TOKEN_ID, sceneId: SCENE_ID, actorId: 'actorididididid1' }],
+        parentUuid: `Combat.${COMBAT_ID}`,
+      },
+    });
+  });
+
+  it('startCombat skips the Combatant create when there are no combatants', async () => {
+    const SCENE_ID = 'sceneididididid1';
+    const { client, emit } = buildClient({});
+    const result = await client.startCombat(SCENE_ID, []);
+    expect(result).toEqual({ combatId: COMBAT_ID, combatantCount: 0 });
+    expect(emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('startCombat rejects a malformed scene id', async () => {
+    const { client } = buildClient({});
+    await expect(client.startCombat('short', [])).rejects.toThrow(/Invalid sceneId/);
+  });
+
+  it('startCombat rejects a malformed token id', async () => {
+    const { client } = buildClient({});
+    await expect(
+      client.startCombat('sceneididididid1', [{ tokenId: 'short', sceneId: 'sceneididididid1' }]),
+    ).rejects.toThrow(/Invalid tokenId/);
+  });
+
+  it('startCombat rejects writes when FOUNDRY_WRITE_ENABLED is false', async () => {
+    const { client } = buildClient({ writeEnabled: false });
+    await expect(client.startCombat('sceneididididid1', [])).rejects.toThrow(
+      /FOUNDRY_WRITE_ENABLED/,
+    );
   });
 
   it('rejects writes when FOUNDRY_WRITE_ENABLED is false', async () => {

--- a/src/tools/handlers/combat-mutations.ts
+++ b/src/tools/handlers/combat-mutations.ts
@@ -10,8 +10,15 @@
 
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { FoundryClient } from '../../foundry/client.js';
-import type { WorldCombat } from '../../foundry/types.js';
+import type { WorldCombat, WorldScene } from '../../foundry/types.js';
 import { withToolError } from './utils.js';
+
+/** A combatant seed derived from a scene token, sent to the create wire. */
+interface CombatantSeed {
+  tokenId: string;
+  sceneId: string;
+  actorId?: string | undefined;
+}
 
 /**
  * Computes the next `{ turn, round }` for an active combat.
@@ -19,36 +26,62 @@ import { withToolError } from './utils.js';
  * Advances to the next combatant in order; wrapping past the last combatant
  * rolls over to turn 0 of the next round.
  *
- * Known limitation: this does NOT skip `defeated` combatants the way Foundry's
- * `Combat#nextTurn` does with `skipDefeated`. Turn order is treated as the raw
- * combatant array order. Defeated-skipping is deferred to a follow-up.
+ * When `skipDefeated` is true, `defeated` combatants are skipped — mirroring
+ * Foundry's `Combat#nextTurn`/`nextRound` with the `skipDefeated` setting. If
+ * every combatant is defeated, the round still advances (turn 0), matching
+ * Foundry's "none remaining" fallback rather than hanging.
  *
  * @throws if the combat has no combatants (cannot advance an empty encounter).
  */
-export function computeNextTurn(combat: WorldCombat): { turn: number; round: number } {
-  const n = combat.combatants.length;
+export function computeNextTurn(
+  combat: WorldCombat,
+  skipDefeated = false,
+): { turn: number; round: number } {
+  const combatants = combat.combatants;
+  const n = combatants.length;
   if (n === 0) {
     throw new Error('Cannot advance turn: active combat has no combatants');
   }
+
   const cur = combat.turn ?? 0;
-  const next = cur + 1;
-  if (next >= n) {
-    return { turn: 0, round: combat.round + 1 };
+
+  // Scan forward within the current round for the next eligible combatant.
+  for (let i = cur + 1; i < n; i++) {
+    if (skipDefeated && combatants[i]?.defeated) {
+      continue;
+    }
+    return { turn: i, round: combat.round };
   }
-  return { turn: next, round: combat.round };
+
+  // No eligible combatant left this round — advance to the next round.
+  const round = combat.round + 1;
+  if (!skipDefeated) {
+    return { turn: 0, round };
+  }
+  const firstAlive = combatants.findIndex((c) => !c.defeated);
+  return { turn: firstAlive === -1 ? 0 : firstAlive, round };
 }
 
 /**
  * Advances the active combat to the next turn (FR-018).
+ *
+ * Accepts an optional `skipDefeated` argument; when omitted it falls back to the
+ * combat's `settings.skipDefeated` (if present in the worldData snapshot), then
+ * to `false`.
  */
-export async function handleNextTurn(_args: Record<string, unknown>, foundryClient: FoundryClient) {
+export async function handleNextTurn(
+  args: { skipDefeated?: boolean },
+  foundryClient: FoundryClient,
+) {
   const combat = foundryClient.getCombatState();
   if (!combat) {
     throw new McpError(ErrorCode.InvalidRequest, 'No active combat to advance.');
   }
 
+  const skipDefeated = args?.skipDefeated ?? combat.settings?.skipDefeated ?? false;
+
   return withToolError('advance combat turn', async () => {
-    const { turn, round } = computeNextTurn(combat);
+    const { turn, round } = computeNextTurn(combat, skipDefeated);
     await foundryClient.updateCombat(combat._id, { turn, round });
 
     const current = combat.combatants[turn];
@@ -136,6 +169,74 @@ export async function handleSetInitiative(
 **Combat:** ${resolvedCombatId}
 **Combatant:** ${combatantId}
 **Initiative:** ${initiative}`,
+        },
+      ],
+    };
+  });
+}
+
+/**
+ * Starts a new combat encounter, seeding combatants from tokens (FR-018, #172).
+ *
+ * Resolves the target scene (explicit `sceneId`, else the active scene), then
+ * builds combatant seeds from the requested `tokenIds` (or every token on the
+ * scene when none are given) and delegates the two-step create to the client.
+ */
+export async function handleStartCombat(
+  args: { tokenIds?: string[]; sceneId?: string },
+  foundryClient: FoundryClient,
+) {
+  const { tokenIds, sceneId } = args ?? {};
+
+  const scenes = foundryClient.getScenes();
+  const scene: WorldScene | undefined = sceneId
+    ? scenes.find((s) => s._id === sceneId)
+    : scenes.find((s) => s.active);
+
+  if (!scene) {
+    throw new McpError(
+      ErrorCode.InvalidRequest,
+      sceneId
+        ? `Scene not found: ${sceneId}`
+        : 'No active scene to start combat on; provide a sceneId.',
+    );
+  }
+
+  const sceneTokens = scene.tokens ?? [];
+  const tokenIdOf = (t: Record<string, unknown>): string | undefined =>
+    typeof t._id === 'string' ? t._id : undefined;
+  const actorIdOf = (t: Record<string, unknown>): string | undefined =>
+    typeof t.actorId === 'string' ? t.actorId : undefined;
+
+  const seeds: CombatantSeed[] = [];
+  if (tokenIds && tokenIds.length > 0) {
+    for (const id of tokenIds) {
+      const token = sceneTokens.find((t) => tokenIdOf(t) === id);
+      if (!token) {
+        throw new McpError(ErrorCode.InvalidParams, `Token not found on scene ${scene._id}: ${id}`);
+      }
+      seeds.push({ tokenId: id, sceneId: scene._id, actorId: actorIdOf(token) });
+    }
+  } else {
+    for (const t of sceneTokens) {
+      const id = tokenIdOf(t);
+      if (id) {
+        seeds.push({ tokenId: id, sceneId: scene._id, actorId: actorIdOf(t) });
+      }
+    }
+  }
+
+  return withToolError('start combat', async () => {
+    const { combatId, combatantCount } = await foundryClient.startCombat(scene._id, seeds);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `⚔️ **Combat Started**
+**Encounter:** ${combatId}
+**Scene:** ${scene.name} (${scene._id})
+**Combatants:** ${combatantCount}`,
         },
       ],
     };

--- a/src/tools/router.ts
+++ b/src/tools/router.ts
@@ -17,6 +17,7 @@ import {
   handleEndCombat,
   handleNextTurn,
   handleSetInitiative,
+  handleStartCombat,
 } from './handlers/combat-mutations.js';
 import { handleSearchCompendium } from './handlers/compendium.js';
 import {
@@ -180,7 +181,7 @@ export async function routeToolRequest(
 
     // Combat mutation tools (FR-018, WRITE — require FOUNDRY_WRITE_ENABLED)
     case 'next_turn':
-      return handleNextTurn(args, foundryClient);
+      return handleNextTurn(args as { skipDefeated?: boolean }, foundryClient);
     case 'end_combat':
       return handleEndCombat(args, foundryClient);
     case 'set_initiative':
@@ -194,6 +195,8 @@ export async function routeToolRequest(
         args as { combatantId: string; initiative: number; combatId?: string },
         foundryClient,
       );
+    case 'start_combat':
+      return handleStartCombat(args as { tokenIds?: string[]; sceneId?: string }, foundryClient);
 
     // Token mutation tools (FR-019, WRITE — require FOUNDRY_WRITE_ENABLED)
     case 'move_token':

--- a/tests/integration/combat.integration.test.ts
+++ b/tests/integration/combat.integration.test.ts
@@ -22,12 +22,15 @@
 
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import type { FoundryClient } from '../../src/foundry/client.js';
-import type { WorldCombat } from '../../src/foundry/types.js';
+import type { WorldCombat, WorldScene } from '../../src/foundry/types.js';
 import { createConnectedClient } from './setup.js';
 
 describe('Combat write operations', () => {
   let client: FoundryClient;
   let combat: WorldCombat | null = null;
+  // Gate for start_combat: an active scene with at least one token AND no
+  // pre-existing active combat (so we don't disturb a running encounter).
+  let startableScene: WorldScene | null = null;
 
   beforeAll(async () => {
     // Writes are opt-in (FOUNDRY_WRITE_ENABLED) and require the Socket.IO
@@ -39,6 +42,13 @@ describe('Combat write operations', () => {
     const active = client.getCombatState();
     if (active && active.combatants.length > 0) {
       combat = active;
+    }
+
+    if (!active) {
+      const scene = client.getScenes().find((s) => s.active && (s.tokens?.length ?? 0) > 0);
+      if (scene) {
+        startableScene = scene;
+      }
     }
   });
 
@@ -88,6 +98,38 @@ describe('Combat write operations', () => {
       await client.updateCombat(combat!._id, { turn: originalTurn, round: originalRound });
 
       expect(true).toBe(true);
+    })();
+  });
+
+  it('start_combat creates an encounter from scene tokens then cleans it up', (ctx) => {
+    if (!startableScene) {
+      return ctx.skip();
+    }
+    return (async () => {
+      const scene = startableScene!;
+      const tokenId = (scene.tokens![0] as { _id?: string })._id;
+      const actorId = (scene.tokens![0] as { actorId?: string }).actorId;
+
+      let combatId: string | undefined;
+      try {
+        const seeds = tokenId ? [{ tokenId, sceneId: scene._id, actorId }] : [];
+        const created = await client.startCombat(scene._id, seeds);
+        combatId = created.combatId;
+
+        expect(created.combatId).toBeTruthy();
+        expect(created.combatantCount).toBe(seeds.length);
+
+        // worldData is stale after a write — refresh, then confirm the new
+        // encounter is the active combat.
+        await client.refreshWorldData();
+        const active = client.getCombatState();
+        expect(active?._id).toBe(combatId);
+      } finally {
+        // Always remove the encounter we created, leaving world state unchanged.
+        if (combatId) {
+          await client.endCombat(combatId);
+        }
+      }
     })();
   });
 });


### PR DESCRIPTION
Implements the two remaining deferred FR-018 combat write follow-ups.

Closes #172
Closes #173

## #172 — `start_combat`

New write tool that creates a combat encounter and seeds its combatants over the Socket.IO `modifyDocument` protocol:

- **Client** `startCombat(sceneId, combatants)` (`src/foundry/client.ts`) — two-step flow: create the top-level `Combat` document (`active: true` on the scene, no `parentUuid`), read its `_id`, then create embedded `Combatant` documents with `parentUuid: "Combat.<id>"` (mirrors `setCombatantInitiative`). Validates `sceneId`/`tokenId` formats and gates on `assertWriteable()`.
- **Handler** `handleStartCombat({ tokenIds?, sceneId? })` — resolves the target scene (explicit `sceneId`, else the active scene), builds combatant seeds from the requested `tokenIds` (or every token on the scene when omitted), resolving each token's `actorId` from the scene token record.
- Tool definition + router case added.

## #173 — `next_turn` skips defeated combatants

`computeNextTurn` now skips `defeated` combatants when `skipDefeated` is set, mirroring Foundry's `Combat#nextTurn`/`nextRound`: it scans forward within the round, wraps to the next round's first non-defeated combatant, and falls back to turn 0 when every combatant is defeated (matching Foundry's "none remaining" behavior). `handleNextTurn` resolves the flag as `args.skipDefeated ?? combat.settings?.skipDefeated ?? false`. A `skipDefeated` arg is added to the tool schema and an optional `settings` field to the `WorldCombat` type.

## Tests

- Unit: 6 `computeNextTurn` skip scenarios (mid-list, trailing, lone survivor, all-defeated, regression guard), `handleNextTurn` skip cases, `handleStartCombat` handler cases, and client wire-shape assertions (Combat `create` with no `parentUuid`, then Combatant `create` with `parentUuid`).
- Integration (gated): live `start_combat` round-trip — create from active-scene tokens → `refreshWorldData` → assert active combat → `end_combat` cleanup. Skips unless an active scene with tokens and no pre-existing active combat are present.
- `just qa` equivalent green locally: `tsc` clean, 314 unit tests pass, biome clean.

Updates `docs/prps/implement-write-operations.md` status.

> ⚠️ The `modifyDocument` **create** wire shape for `Combat`/`Combatant` should be smoke-tested against a live v13.348 world per `.claude/rules/foundry-write-protocol.md` before merge — the update/delete shapes were already verified, but this is the first create on these document types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LM631tFFbm8BvuUq6dFSht

---
_Generated by [Claude Code](https://claude.ai/code/session_01LM631tFFbm8BvuUq6dFSht)_