### PR TITLE
fix(mcp): correct transport drift and repair test-connection script

### DIFF
--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -17,7 +17,18 @@ local/CI parity.
 
 - Connects through the shared helper `tests/integration/setup.ts`
   (`createConnectedClient`) in Socket.IO mode (`FOUNDRY_USERNAME`/`FOUNDRY_PASSWORD`).
-- `tests/integration/global-setup.ts` waits for the container to be ready.
+- `tests/integration/global-setup.ts` only **waits** for the container at
+  `:30001` — it does **not** start it.
+- **Running it:** needs (a) `.env.integration` (copy from
+  `.env.integration.example`, add a real `FOUNDRY_LICENSE_KEY` — the file is
+  gitignored and ships only as the `.example`) and (b) the ephemeral test
+  container up on `:30001`. Use **`just test-integration-docker`** (wraps `bun
+  run test:integration:docker`: `docker-compose.test.yml up --wait` → run suite
+  → `down -v`). Plain `just test-integration` assumes the `:30001` container is
+  already running and otherwise blocks ~120s before failing in global-setup.
+- The test container uses tmpfs `/data` + `CONTAINER_PRESERVE_CONFIG=false`, so
+  it starts world-less; Socket.IO auth specs need a bootstrapped world (still
+  manual — the CI wiring for this tier is gated on `FOUNDRY_*` secrets, issue #140).
 - **Write-tool tests** (`mutations.integration.test.ts`) exercise the
   `modifyDocument` write protocol: they require `writeEnabled: true` and a world
   **GM** user, target an actor with a mutable attribute, and **revert every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Model Context Protocol (MCP) server bridging AI assistants with FoundryVTT table
 bun run build          # Compile TypeScript
 bun run dev            # Development mode with hot reload
 bun test               # Unit tests (Vitest)
-bun run test:integration # Integration tests (live FoundryVTT, port 30001)
+bun run test:integration # Integration tests (needs :30001 container + .env.integration — prefer `just test-integration-docker`)
 bun run test:e2e       # E2E tests (Playwright, headless)
 bun run lint           # Lint code (Biome)
 bun run lint:fix       # Auto-fix lint issues
@@ -44,10 +44,18 @@ bun run test-connection # Test MCP→FoundryVTT connection
 | Router | `src/tools/router.ts` | Request→handler dispatch |
 | Types | `src/foundry/types.ts` | FoundryVTT entity interfaces |
 
-### Authentication
+### Authentication & transport selection
 
-- **Primary**: Socket.IO with `FOUNDRY_USERNAME`/`FOUNDRY_PASSWORD`
-- **Optional**: `FOUNDRY_API_KEY` for REST API diagnostics (5 extra tools)
+`client.ts` selects transport purely by whether `FOUNDRY_API_KEY` is set:
+
+- **`FOUNDRY_API_KEY` unset → Socket.IO mode** (default): authenticates with
+  `FOUNDRY_USERNAME`/`FOUNDRY_PASSWORD` and loads full `worldData`.
+- **`FOUNDRY_API_KEY` set → REST API mode**: connects to the REST module's
+  `/api/status` instead. This is a transport **switch**, not an additive layer —
+  it does not run alongside the Socket.IO `worldData` path.
+- `USE_REST_MODULE` (seen in some `.env`/example files and the `test-connection`
+  tips) is **not read** by `src/config/index.ts` — it is a no-op. Transport is
+  decided solely by `apiKey` presence.
 
 ## Environment Variables
 

--- a/justfile
+++ b/justfile
@@ -81,10 +81,15 @@ test-coverage:
 test-connection:
     bun run test-connection
 
-# Run integration tests
+# Run integration tests against an ALREADY-RUNNING :30001 container (needs .env.integration)
 [group: "test"]
 test-integration *args:
     bun run test:integration {{ args }}
+
+# Boot the ephemeral :30001 test container, run integration tests, tear it down (needs .env.integration)
+[group: "test"]
+test-integration-docker:
+    bun run test:integration:docker
 
 ########## E2E Testing ##########
 

--- a/scripts/test-connection.ts
+++ b/scripts/test-connection.ts
@@ -35,14 +35,15 @@ async function testConnection() {
       console.log(`   Setup Type: 🖥️  Remote/Network`);
     }
     
-    console.log(`   REST Module: ${config.foundry.useRestModule ? '✅' : '❌'}`);
+    // Transport is selected purely by apiKey presence (client.ts): set → REST
+    // API mode; unset → Socket.IO mode (the default, full worldData path).
+    console.log(`   Transport: ${config.foundry.apiKey ? '🌐 REST API' : '🔌 Socket.IO'}`);
     console.log(`   API Key: ${config.foundry.apiKey ? '✅ Configured' : '❌ Not set'}`);
     console.log(`   Username: ${config.foundry.username ? '✅ Configured' : '❌ Not set'}\n`);
 
     // Initialize client
     const client = new FoundryClient({
       baseUrl: config.foundry.url,
-      useRestModule: config.foundry.useRestModule,
       apiKey: config.foundry.apiKey,
       username: config.foundry.username,
       password: config.foundry.password,
@@ -97,17 +98,17 @@ async function testConnection() {
       console.log(`⚠️  Scene info limited: ${error instanceof Error ? error.message : error}\n`);
     }
 
-    // Test WebSocket connection
-    console.log('🔌 Testing WebSocket connection...');
+    // Test the live Socket.IO connection (no-op equivalent in REST mode)
+    console.log('🔌 Testing Socket.IO connection...');
     try {
-      await client.connectWebSocket();
-      console.log('✅ WebSocket connection established!\n');
+      await client.connect();
+      console.log('✅ Socket.IO connection established!\n');
 
       // Give it a moment to connect
       await new Promise(resolve => setTimeout(resolve, 2000));
 
       await client.disconnect();
-      console.log('✅ WebSocket disconnected cleanly\n');
+      console.log('✅ Disconnected cleanly\n');
     } catch (error) {
       console.log(`⚠️  WebSocket connection issues: ${error instanceof Error ? error.message : error}\n`);
     }
@@ -116,14 +117,14 @@ async function testConnection() {
     console.log('\n📝 Summary:');
     console.log('   - Basic connection: ✅');
     console.log('   - Dice rolling: ✅');
-    console.log(`   - Data access: ${config.foundry.useRestModule ? '✅ Full' : '⚠️  Limited'}`);
-    console.log(`   - WebSocket: ${config.foundry.useRestModule ? '✅' : '⚠️  Basic'}`);
+    console.log(`   - Data access: ${config.foundry.apiKey ? '⚠️  REST (limited)' : '✅ Full worldData'}`);
+    console.log(`   - Connection: ${config.foundry.apiKey ? '🌐 REST API' : '🔌 Socket.IO'}`);
 
-    if (!config.foundry.useRestModule) {
-      console.log('\n💡 Tips for enhanced functionality:');
+    if (!config.foundry.apiKey) {
+      console.log('\n💡 Optional: the "Foundry REST API" module adds the diagnostics + compendium path.');
       console.log('   1. Install the "Foundry REST API" module in FoundryVTT');
-      console.log('   2. Get the API key from the module configuration page in FoundryVTT');
-      console.log('   3. Set USE_REST_MODULE=true and FOUNDRY_API_KEY in .env');
+      console.log('   2. Copy the API key from the module configuration page');
+      console.log('   3. Set FOUNDRY_API_KEY in .env (this switches the client to REST transport)');
       console.log('   4. Restart the MCP server');
     }
 

--- a/src/config/__tests__/index.test.ts
+++ b/src/config/__tests__/index.test.ts
@@ -170,7 +170,6 @@ describe('Config', () => {
     it('should convert string booleans to booleans', async () => {
       process.env = {
         FOUNDRY_URL: 'http://localhost:30000',
-        USE_REST_MODULE: 'true',
         CACHE_ENABLED: 'false',
       };
 

--- a/src/tools/router.ts
+++ b/src/tools/router.ts
@@ -97,7 +97,8 @@ export async function routeToolRequest(
       }
       return handleGetActorDetails(args as { actorId: string }, foundryClient);
 
-    // Actor mutation tools (#143, require REST API module)
+    // Actor mutation tools (#143) — WRITE via the Socket.IO modifyDocument
+    // protocol (foundryClient); require FOUNDRY_WRITE_ENABLED=true + a GM user.
     case 'update_actor_attributes':
       if (!('actorId' in args) || typeof args.actorId !== 'string') {
         throw new Error('Missing required parameter: actorId');
@@ -135,7 +136,8 @@ export async function routeToolRequest(
         foundryClient,
       );
 
-    // Item mutation tools (WRITE — require REST API module)
+    // Item mutation tools (WRITE) — Socket.IO modifyDocument protocol
+    // (foundryClient); require FOUNDRY_WRITE_ENABLED=true + a GM user.
     case 'create_actor_item':
       if (!('actorId' in args) || typeof args.actorId !== 'string') {
         throw new Error('Missing required parameter: actorId');


### PR DESCRIPTION
## Summary

While verifying the `foundryvtt-mcp` dev workflow against the running harness, several doc↔code drifts and two real script bugs surfaced. The verified model: **Socket.IO is the primary transport**, and `FOUNDRY_API_KEY` presence is a transport *switch* (Socket.IO ↔ REST), not an additive layer.

## Bugs fixed

- **`scripts/test-connection.ts` called `client.connectWebSocket()`** — a method that doesn't exist → runtime `is not a function`. Now calls `client.connect()`. (`scripts/` is outside the `tsc` set, so this was never caught at build time — only at runtime.)
- **`USE_REST_MODULE` / `config.foundry.useRestModule` is dead config** — never parsed by `src/config/index.ts`, absent from `FoundryClientConfig`, so always `undefined`. The connection script's transport display and tips keyed off it (hence the always-`❌ REST Module` line), and a config test fixture set it for nothing. Display now keys off `apiKey`; dead references removed.
- **`router.ts` mutation comments claimed actor/item writes "require REST API module"** — they write via the Socket.IO `modifyDocument` protocol (`foundryClient`), per `foundry-write-protocol.md`. Comments corrected.

## Docs & tooling

- **`justfile`**: added `test-integration-docker` (wraps `bun run test:integration:docker`, which actually boots the `:30001` container — there was no `just` recipe for it); clarified `test-integration` assumes the container is already running.
- **`.claude/rules/testing.md`**: documented the integration-tier prerequisites (`.env.integration`, the `:30001` container, manual world bootstrap; CI gated on `FOUNDRY_*` secrets / #140).
- **`CLAUDE.md`**: rewrote the transport/authentication section (apiKey = transport switch, not additive "5 extra tools"); flagged `USE_REST_MODULE` as a no-op.

## Verification

- `just qa` green: biome clean, `tsc` clean, **296 unit tests pass**.
- `bun run test-connection` now runs end-to-end with no runtime error and reports the correct transport.
- Harness confirmed healthy during investigation (felddy v13.348, world loaded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)