### PR TITLE
docs(rules): note scripts/ is outside the tsc surface

### DIFF
--- a/.claude/rules/scripts-typecheck-gap.md
+++ b/.claude/rules/scripts-typecheck-gap.md
@@ -1,0 +1,52 @@
+# `scripts/` Is Outside the Typecheck Surface — Smoke-Run It
+
+`tsconfig.json` sets `include: ["src/**/*"]`, so **nothing under `scripts/`
+is typechecked**. `bunx tsc --noEmit`, `just qa`, and CI all pass while a
+helper script calls a nonexistent method or reads a property that doesn't
+exist — the failure only appears at **runtime**, when you actually run the
+script.
+
+## The cost (real: PR #193)
+
+`scripts/test-connection.ts` carried two latent bugs that the build never
+caught because the file isn't in the `tsc` set:
+
+| Bug | Why tsc would have caught it | Failed at |
+|-----|------------------------------|-----------|
+| `client.connectWebSocket()` | no such method on `FoundryClient` (it's `connect()`) | runtime → `is not a function` |
+| `config.foundry.useRestModule` | property absent from the config type | runtime → silently `undefined`, drove wrong output |
+
+Both shipped green through `just qa` and CI; only `bun run test-connection`
+surfaced them.
+
+## The habit
+
+- **When editing anything under `scripts/`, run it** (`bun run <script>` /
+  `bunx tsx scripts/<x>.ts`) before trusting it. The typechecker will not
+  flag method/property typos there.
+- **Don't assume `just qa` covers a script** — it covers `src/` only.
+
+## Durable fix (preferred)
+
+Bring `scripts/` into the typecheck surface so these fail at build, not
+runtime. Either widen the main config or add a dedicated one:
+
+```jsonc
+// tsconfig.scripts.json
+{ "extends": "./tsconfig.json", "include": ["scripts/**/*"] }
+```
+
+```just
+# justfile — wire into qa
+check-types-scripts:
+    bunx tsc --noEmit -p tsconfig.scripts.json
+```
+
+Adding `scripts/` to the checked set will surface any remaining drift there
+in one pass (expect a few fixes the first time) — that is the point.
+
+## When this bites
+
+Any repo whose `tsconfig` `include` is `src/**` while real, runnable code
+lives in `scripts/`, `tools/`, `bin/`, or similar. The same gap applies to
+the linter if its globs are `src`-only.


### PR DESCRIPTION
## Summary

Distilled from #193: the two script bugs that PR fixed (`client.connectWebSocket()` — a nonexistent method; `config.foundry.useRestModule` — a property that doesn't exist) both shipped green through `just qa` and CI, because `tsconfig.json` has `include: ["src/**/*"]` and **`scripts/` is never typechecked**. They only failed at runtime.

Adds `.claude/rules/scripts-typecheck-gap.md` capturing:
- the gotcha (scripts/ outside the tsc set; `just qa`/CI don't cover it),
- the habit (smoke-run scripts when editing — typos there are invisible to the typechecker),
- the durable fix (a `tsconfig.scripts.json` wired into `qa` so they fail at build instead).

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)