### PR TITLE
fix(scripts): report REST 404s as missing endpoints, not degraded state

### DIFF
--- a/scripts/test-connection.ts
+++ b/scripts/test-connection.ts
@@ -5,12 +5,29 @@
  * Run with: npm run test-connection
  */
 
+import axios from 'axios';
 import dotenv from 'dotenv';
 import { FoundryClient } from '../src/foundry/client.js';
 import { config } from '../src/config/index.js';
 import { logger } from '../src/utils/logger.js';
 
 dotenv.config({ quiet: true });
+
+/**
+ * True when a REST-mode request failed because the target's REST module does
+ * not serve the route at all (the bridge's catch-all 404), as opposed to a
+ * transport or server error. See issue #194.
+ */
+function isRestRouteMissing(error: unknown): boolean {
+  return axios.isAxiosError(error) && error.response?.status === 404;
+}
+
+function printRestRouteMissing(what: string, route: string): void {
+  console.log(`ℹ️  ${what} not exposed by this REST module (404 on ${route}).`);
+  console.log('   The target instance\'s REST module does not serve this endpoint —');
+  console.log('   expected with older/other REST module builds; not a client defect.');
+  console.log('   Actor/scene reads are canonical over Socket.IO: unset FOUNDRY_API_KEY.\n');
+}
 
 async function testConnection() {
   console.log('🧪 FoundryVTT MCP Server - Connection Test\n');
@@ -84,7 +101,11 @@ async function testConnection() {
         console.log('ℹ️  No actors found (may require REST API module)\n');
       }
     } catch (error) {
-      console.log(`⚠️  Actor search limited: ${error instanceof Error ? error.message : error}\n`);
+      if (config.foundry.apiKey && isRestRouteMissing(error)) {
+        printRestRouteMissing('Actor search', 'GET /api/actors');
+      } else {
+        console.log(`⚠️  Actor search limited: ${error instanceof Error ? error.message : error}\n`);
+      }
     }
 
     // Test scene info
@@ -95,7 +116,11 @@ async function testConnection() {
       console.log(`   Dimensions: ${scene.width}x${scene.height}`);
       console.log('✅ Scene information works!\n');
     } catch (error) {
-      console.log(`⚠️  Scene info limited: ${error instanceof Error ? error.message : error}\n`);
+      if (config.foundry.apiKey && isRestRouteMissing(error)) {
+        printRestRouteMissing('Scene info', 'GET /api/scenes/current');
+      } else {
+        console.log(`⚠️  Scene info limited: ${error instanceof Error ? error.message : error}\n`);
+      }
     }
 
     // Test the live Socket.IO connection (no-op equivalent in REST mode)
@@ -117,7 +142,7 @@ async function testConnection() {
     console.log('\n📝 Summary:');
     console.log('   - Basic connection: ✅');
     console.log('   - Dice rolling: ✅');
-    console.log(`   - Data access: ${config.foundry.apiKey ? '⚠️  REST (limited)' : '✅ Full worldData'}`);
+    console.log(`   - Data access: ${config.foundry.apiKey ? '🌐 REST (coverage depends on the target module; Socket.IO is the full-data path)' : '✅ Full worldData'}`);
     console.log(`   - Connection: ${config.foundry.apiKey ? '🌐 REST API' : '🔌 Socket.IO'}`);
 
     if (!config.foundry.apiKey) {


### PR DESCRIPTION
## What

In REST mode (`FOUNDRY_API_KEY` set), `scripts/test-connection.ts` now detects a 404 on the actor-search and scene-info probes and reports it explicitly: the target's REST module does not expose that endpoint, this is expected on older/other REST module builds, and Socket.IO mode is the canonical path for actor/scene reads. Previously these printed `⚠️ Actor search limited: Request failed with status code 404`, implying a degraded-but-fixable client-side state. The summary line likewise no longer labels REST as "limited".

## Investigation (issue #194)

- The client's REST routes (`GET /api/actors`, `GET /api/actors/:id`, `GET /api/scenes/current`, `GET /api/scenes/:id`, `POST /api/dice/roll`, `GET /api/status`, `GET /api/world`) **exactly match** the bridge-server's current route table (`foundryvtt-local-rest-api/bridge-server/server.js` + `routes/`). No client/route mismatch.
- The bridge's actor/scene routes map upstream failures to **500**, never 404. A 404 can only come from Express's catch-all `app.use('*')` handler — i.e. the route was not registered at all on the target instance.
- Conclusion: the observed 404s (status ✅, dice ✅, actors/scenes ❌) mean the remote instance runs an older/different REST module build that lacks those routes — a **target-side version gap, not a client defect**. Per `foundry-write-protocol.md`, Socket.IO is the primary transport and the REST path is optional diagnostics, so the right client-side fix is honest reporting.

## Verification

- Reproduced the exact issue scenario with a stub server (`/api/status` + dice 200, everything else 404): script now prints the explicit ℹ️ explanation for both probes.
- Smoke-ran the script directly (`scripts/` is outside the tsc surface, per `.claude/rules/scripts-typecheck-gap.md`).
- `just qa` green (biome + tsc + 314 unit tests).

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GrdRRhzWjmN2xGnUKN311