### PR TITLE
chore(mcp): add pal-mcp-server to project MCP config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,31 +6,20 @@
     },
     "context7": {
       "command": "bunx",
-      "args": [
-        "-y",
-        "@upstash/context7-mcp"
-      ]
+      "args": ["-y", "@upstash/context7-mcp"]
     },
     "playwright": {
       "command": "bunx",
-      "args": [
-        "-y",
-        "@playwright/mcp@latest"
-      ]
+      "args": ["-y", "@playwright/mcp@latest"]
     },
     "sequential-thinking": {
       "command": "bunx",
-      "args": [
-        "-y",
-        "@modelcontextprotocol/server-sequential-thinking"
-      ]
+      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
     },
     "chrome-devtools": {
       "type": "stdio",
       "command": "bunx",
-      "args": [
-        "chrome-devtools-mcp@latest"
-      ],
+      "args": ["chrome-devtools-mcp@latest"],
       "env": {}
     },
     "github": {
@@ -43,6 +32,17 @@
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_PERSONAL_ACCESS_TOKEN}"
       }
+    },
+    "pal-mcp-server": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": [
+        "--from",
+        "git+https://github.com/laurigates/pal-mcp-server.git",
+        "pal-mcp-server"
+      ],
+      "env": {}
     }
   }
 }
+


### PR DESCRIPTION
## What

Adds the PAL MCP server to `.mcp.json` (uvx git source, stdio transport) and normalizes the args-array formatting; adds the missing trailing newline.

## Why

Makes the PAL model-gateway tools (chat/consensus/codereview against external models) available in Claude Code sessions in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWQu8JEyGV19S2YRTZfzAw