### PR TITLE
ci: add Claude Code workflows and project Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,34 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git:*)",
+      "Bash(gh:*)",
+      "Bash(pre-commit:*)",
+      "Bash(gitleaks:*)",
+      "Bash(python3:*)",
+      "Bash(npm:*)",
+      "Bash(pnpm:*)",
+      "Bash(bun:*)",
+      "Bash(tsc:*)",
+      "Bash(eslint:*)",
+      "Bash(prettier:*)",
+      "Bash(vitest:*)"
+    ]
+  },
+  "extraKnownMarketplaces": {
+    "claude-plugins": {
+      "source": { "source": "github", "repo": "laurigates/claude-plugins" },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "code-quality-plugin@claude-plugins": true,
+    "configure-plugin@claude-plugins": true,
+    "git-plugin@claude-plugins": true,
+    "github-actions-plugin@claude-plugins": true,
+    "health-plugin@claude-plugins": true,
+    "hooks-plugin@claude-plugins": true,
+    "testing-plugin@claude-plugins": true,
+    "typescript-plugin@claude-plugins": true
+  }
+}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,36 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Review this pull request. Focus on:
+            - Code quality and best practices
+            - Potential bugs or security issues
+            - Test coverage gaps
+            - Documentation needs
+          claude_args: "--max-turns 5"
+          plugin_marketplaces: |
+            https://github.com/laurigates/claude-plugins.git
+          plugins: |
+            code-quality-plugin@laurigates-claude-plugins
+            testing-plugin@laurigates-claude-plugins

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,44 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: |
+            https://github.com/laurigates/claude-plugins.git
+          plugins: |
+            git-plugin@laurigates-claude-plugins
+            typescript-plugin@laurigates-claude-plugins
+            testing-plugin@laurigates-claude-plugins
+            code-quality-plugin@laurigates-claude-plugins
+            github-actions-plugin@laurigates-claude-plugins
+            configure-plugin@laurigates-claude-plugins
+            health-plugin@laurigates-claude-plugins
+            hooks-plugin@laurigates-claude-plugins

--- a/.project-standards.yaml
+++ b/.project-standards.yaml
@@ -1,0 +1,9 @@
+standards_version: "2025.1"
+project_type: typescript
+last_configured: "2026-05-12"
+components:
+  docs: "2025.1"
+  docs_level: standard
+  docs_languages:
+    - typescript
+  docs_generator: typedoc


### PR DESCRIPTION
## What

- `.github/workflows/claude.yml` — interactive @claude workflow on issue/PR comments and issue open/assign
- `.github/workflows/claude-code-review.yml` — automated Claude review on PR open/synchronize/reopen
- `.claude/settings.json` — committed plugin enablement (claude-plugins marketplace) so web/remote/CI sessions get the plugin set, plus a Bash permission allowlist
- `.project-standards.yaml` — configure-plugin standards marker (docs component, typedoc)

## Why

Onboards the repo to the Claude Code GitHub integration and the laurigates/claude-plugins marketplace. The `CLAUDE_CODE_OAUTH_TOKEN` secret is already configured on the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWQu8JEyGV19S2YRTZfzAw