### PR TITLE
feat(tools): add create_journal_entry write tool (carries #202 + page sort fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ needs GM/owner permission. Set `FOUNDRY_WRITE_ENABLED=true` to enable them.
 - `create_actor_item` — add an inline item to an actor
 - `update_actor_item` — apply a JSON merge patch to an actor's item
 - `delete_actor_item` — remove an item from an actor
+- `create_journal_entry` — create a journal entry with one or more text pages
 
 ### World
 

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -37,6 +37,14 @@ import type {
 const FOUNDRY_ID_PATTERN = /^[a-zA-Z0-9]{16}$/;
 
 /**
+ * Spacing between sibling `sort` values, mirroring Foundry's
+ * `CONST.SORT_INTEGER_DENSITY`. Leaving every sibling at the default `0` makes
+ * ordering depend on incidental collection insertion order, and gives Foundry
+ * no gap to slot a UI-created sibling into later.
+ */
+const SORT_INTEGER_DENSITY = 100000;
+
+/**
  * Accepts the two parent-UUID forms a token's actor can take:
  *  - `Actor.<id>` — a world-linked actor (`actorLink: true`)
  *  - `Scene.<sid>.Token.<tid>.Actor.<aid>` — an unlinked token's synthetic actor
@@ -1147,7 +1155,8 @@ export class FoundryClient {
    * `JournalEntry` is a top-level document (unlike Item/ActiveEffect, which
    * are embedded in an Actor), so the create carries no `parentUuid` —
    * mirrors {@link startCombat}'s top-level Combat create. Each entry in
-   * `pages` is mapped to Foundry's native `JournalEntryPage` text-page shape.
+   * `pages` is mapped to Foundry's native `JournalEntryPage` text-page shape,
+   * with an explicit `sort` so the pages render in the order supplied.
    *
    * @param name - journal entry title
    * @param pages - one or more pages (name + content); at least one required
@@ -1172,10 +1181,11 @@ export class FoundryClient {
 
     const data: Record<string, unknown> = {
       name,
-      pages: pages.map((p) => ({
+      pages: pages.map((p, i) => ({
         name: p.name,
         type: 'text',
         text: { content: p.content, format: 1 },
+        sort: (i + 1) * SORT_INTEGER_DENSITY,
       })),
     };
     if (folder) {

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -21,6 +21,7 @@ import type {
   FoundryScene,
   FoundryWorld,
   ItemSearchResult,
+  JournalPageCreateSource,
   WorldActor,
   WorldCombat,
   WorldData,
@@ -1134,6 +1135,57 @@ export class FoundryClient {
 
   getJournal(journalId: string): WorldJournal | undefined {
     return this.worldData?.journal.find((j) => j._id === journalId);
+  }
+
+  // ==========================================================================
+  // Journal mutation methods (WRITE — Socket.IO modifyDocument)
+  // ==========================================================================
+
+  /**
+   * Creates a new JournalEntry with one or more text pages.
+   *
+   * `JournalEntry` is a top-level document (unlike Item/ActiveEffect, which
+   * are embedded in an Actor), so the create carries no `parentUuid` —
+   * mirrors {@link startCombat}'s top-level Combat create. Each entry in
+   * `pages` is mapped to Foundry's native `JournalEntryPage` text-page shape.
+   *
+   * @param name - journal entry title
+   * @param pages - one or more pages (name + content); at least one required
+   * @param folder - optional 16-char Folder document id to file the entry under
+   * @returns the newly created journal entry document
+   */
+  async createJournalEntry(
+    name: string,
+    pages: JournalPageCreateSource[],
+    folder?: string,
+  ): Promise<WorldJournal> {
+    this.assertWriteable();
+    if (!name || typeof name !== 'string') {
+      throw new Error('name is required and must be a string');
+    }
+    if (!Array.isArray(pages) || pages.length === 0) {
+      throw new Error('pages is required and must contain at least one page');
+    }
+    if (folder !== undefined && !FOUNDRY_ID_PATTERN.test(folder)) {
+      throw new Error(`Invalid folder format: ${folder}`);
+    }
+
+    const data: Record<string, unknown> = {
+      name,
+      pages: pages.map((p) => ({
+        name: p.name,
+        type: 'text',
+        text: { content: p.content, format: 1 },
+      })),
+    };
+    if (folder) {
+      data.folder = folder;
+    }
+
+    const result = await this.modifyDocument('JournalEntry', 'create', {
+      data: [data],
+    });
+    return result[0] as WorldJournal;
   }
 
   // ==========================================================================

--- a/src/foundry/types.ts
+++ b/src/foundry/types.ts
@@ -602,6 +602,19 @@ export type ActorItemCreateSource =
     };
 
 /**
+ * A single page to create on a new journal entry.
+ *
+ * `content` is plain text/HTML for a text-type page; {@link FoundryClient.createJournalEntry}
+ * maps it into Foundry's native `JournalEntryPage` shape
+ * (`type: "text"`, `text: { content, format: 1 }` — format 1 is
+ * `CONST.JOURNAL_ENTRY_PAGE_FORMATS.HTML`).
+ */
+export interface JournalPageCreateSource {
+  name: string;
+  content: string;
+}
+
+/**
  * Result structure for an actor attribute update (#143).
  *
  * Returned by `FoundryClient.updateActorAttribute`. The `updatedAttributes`

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -704,6 +704,50 @@ export const journalTools = [
 ];
 
 /**
+ * Journal mutation tool definitions (WRITE)
+ */
+export const journalMutationTools = [
+  {
+    name: 'create_journal_entry',
+    description:
+      'Create a new journal entry with one or more text pages (requires FOUNDRY_WRITE_ENABLED=true + active Socket.IO connection).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description: 'Title of the journal entry',
+        },
+        pages: {
+          type: 'array',
+          description: 'One or more pages to create on the entry',
+          items: {
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+                description: 'Page title',
+              },
+              content: {
+                type: 'string',
+                description: 'Page body as HTML or plain text',
+              },
+            },
+            required: ['name', 'content'],
+          },
+          minItems: 1,
+        },
+        folder: {
+          type: 'string',
+          description: 'Optional Folder document id to file the entry under',
+        },
+      },
+      required: ['name', 'pages'],
+    },
+  },
+];
+
+/**
  * World-level tool definitions
  */
 export const worldTools = [
@@ -762,6 +806,7 @@ export function getAllTools() {
     ...chatTools,
     ...userTools,
     ...journalTools,
+    ...journalMutationTools,
     ...worldTools,
     ...generationTools,
     ...diagnosticsTools,

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -710,7 +710,7 @@ export const journalMutationTools = [
   {
     name: 'create_journal_entry',
     description:
-      'Create a new journal entry with one or more text pages (requires FOUNDRY_WRITE_ENABLED=true + active Socket.IO connection).',
+      'Create a new journal entry with one or more text pages (requires FOUNDRY_WRITE_ENABLED=true + active Socket.IO connection). The entry is created with default ownership, so it is visible to the GM only until ownership is granted in Foundry. It also will not appear in search_journals/get_journal until refresh_world_data is called.',
     inputSchema: {
       type: 'object',
       properties: {

--- a/src/tools/handlers/__tests__/journal-mutations.test.ts
+++ b/src/tools/handlers/__tests__/journal-mutations.test.ts
@@ -1,0 +1,243 @@
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { describe, expect, it, vi } from 'vitest';
+import { FoundryClient } from '../../../foundry/client.js';
+import type { WorldJournal } from '../../../foundry/types.js';
+import { handleCreateJournalEntry } from '../journal-mutations.js';
+
+const VALID_FOLDER_ID = 'abcdefABCDEF0123';
+
+const sampleJournal: WorldJournal = {
+  _id: '0123456789abcdef',
+  name: 'Session 11 Recap',
+  pages: [
+    {
+      _id: 'fedcba9876543210',
+      name: 'Summary',
+      type: 'text',
+      text: { content: '<p>The party arrived in Terris.</p>', format: 1 },
+    },
+  ],
+};
+
+const createMockClient = (overrides: Partial<FoundryClient> = {}): FoundryClient => {
+  return {
+    createJournalEntry: vi.fn(async () => sampleJournal),
+    ...overrides,
+  } as unknown as FoundryClient;
+};
+
+describe('journal mutation handlers', () => {
+  describe('handleCreateJournalEntry', () => {
+    it('creates a journal entry with a single page', async () => {
+      const mockClient = createMockClient();
+      const result = await handleCreateJournalEntry(
+        {
+          name: 'Session 11 Recap',
+          pages: [{ name: 'Summary', content: '<p>The party arrived in Terris.</p>' }],
+        },
+        mockClient,
+      );
+
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Journal Entry Created');
+      expect(result.content[0].text).toContain('Session 11 Recap');
+      expect(mockClient.createJournalEntry).toHaveBeenCalledWith(
+        'Session 11 Recap',
+        [{ name: 'Summary', content: '<p>The party arrived in Terris.</p>' }],
+        undefined,
+      );
+    });
+
+    it('passes an optional folder id through', async () => {
+      const mockClient = createMockClient();
+      await handleCreateJournalEntry(
+        {
+          name: 'Session 11 Recap',
+          pages: [{ name: 'Summary', content: 'text' }],
+          folder: VALID_FOLDER_ID,
+        },
+        mockClient,
+      );
+
+      expect(mockClient.createJournalEntry).toHaveBeenCalledWith(
+        'Session 11 Recap',
+        [{ name: 'Summary', content: 'text' }],
+        VALID_FOLDER_ID,
+      );
+    });
+
+    it('rejects an empty name with InvalidParams', async () => {
+      const mockClient = createMockClient();
+      await expect(
+        handleCreateJournalEntry(
+          { name: '', pages: [{ name: 'Summary', content: 'text' }] },
+          mockClient,
+        ),
+      ).rejects.toThrow(McpError);
+    });
+
+    it('rejects an empty pages array with InvalidParams', async () => {
+      const mockClient = createMockClient();
+      await expect(
+        handleCreateJournalEntry({ name: 'Session 11 Recap', pages: [] }, mockClient),
+      ).rejects.toThrow(McpError);
+    });
+
+    it('rejects a page missing content with InvalidParams', async () => {
+      const mockClient = createMockClient();
+      await expect(
+        handleCreateJournalEntry(
+          {
+            name: 'Session 11 Recap',
+            pages: [{ name: 'Summary' } as unknown as { name: string; content: string }],
+          },
+          mockClient,
+        ),
+      ).rejects.toThrow(McpError);
+    });
+
+    it('propagates a client error', async () => {
+      const mockClient = createMockClient({
+        createJournalEntry: vi.fn(async () => {
+          throw new Error('FoundryVTT rejected create JournalEntry: some failure');
+        }),
+      });
+      await expect(
+        handleCreateJournalEntry(
+          { name: 'Session 11 Recap', pages: [{ name: 'Summary', content: 'text' }] },
+          mockClient,
+        ),
+      ).rejects.toThrow(McpError);
+    });
+
+    it('surfaces the write-disabled guard error', async () => {
+      const mockClient = createMockClient({
+        createJournalEntry: vi.fn(async () => {
+          throw new Error(
+            'Write operations are disabled. Set FOUNDRY_WRITE_ENABLED=true to allow game-state mutation.',
+          );
+        }),
+      });
+      await expect(
+        handleCreateJournalEntry(
+          { name: 'Session 11 Recap', pages: [{ name: 'Summary', content: 'text' }] },
+          mockClient,
+        ),
+      ).rejects.toThrow('FOUNDRY_WRITE_ENABLED');
+    });
+  });
+});
+
+// ----------------------------------------------------------------------------
+// Client-level: exercises the real createJournalEntry over a mocked Socket.IO
+// socket (modifyDocument protocol).
+// ----------------------------------------------------------------------------
+describe('FoundryClient journal mutations (modifyDocument)', () => {
+  type SocketEmitMock = (event: string, payload: unknown, cb: (response: unknown) => void) => void;
+
+  const buildClient = (opts: { writeEnabled?: boolean; connected?: boolean } = {}) => {
+    const client = new FoundryClient({
+      baseUrl: 'http://localhost:30000',
+      writeEnabled: opts.writeEnabled ?? true,
+    });
+    const emit = vi.fn(((_event, payload, cb) => {
+      const op = (payload as { operation?: { data?: unknown[] } }).operation;
+      const echoed = op?.data?.[0];
+      cb({ result: echoed ? [echoed] : [] });
+    }) as SocketEmitMock);
+    if (opts.connected !== false) {
+      (client as unknown as { socket: { connected: boolean; emit: SocketEmitMock } }).socket = {
+        connected: true,
+        emit,
+      };
+    }
+    return client;
+  };
+
+  const lastRequest = (client: FoundryClient) => {
+    const emitMock = (client as unknown as { socket: { emit: ReturnType<typeof vi.fn> } }).socket
+      .emit;
+    return emitMock.mock.calls[0];
+  };
+
+  it('creates a top-level JournalEntry modifyDocument request with no parentUuid', async () => {
+    const client = buildClient();
+    await client.createJournalEntry('Session 11 Recap', [
+      { name: 'Summary', content: '<p>The party arrived in Terris.</p>' },
+    ]);
+    const [event, body] = lastRequest(client);
+    expect(event).toBe('modifyDocument');
+    expect(body).toMatchObject({
+      type: 'JournalEntry',
+      action: 'create',
+      operation: {
+        data: [
+          {
+            name: 'Session 11 Recap',
+            pages: [
+              {
+                name: 'Summary',
+                type: 'text',
+                text: { content: '<p>The party arrived in Terris.</p>', format: 1 },
+              },
+            ],
+          },
+        ],
+        broadcast: true,
+        pack: null,
+      },
+    });
+    expect(body.operation.parentUuid).toBeUndefined();
+  });
+
+  it('maps multiple pages in order', async () => {
+    const client = buildClient();
+    await client.createJournalEntry('Session 11 Recap', [
+      { name: 'Summary', content: 'a' },
+      { name: 'NPCs', content: 'b' },
+    ]);
+    const [, body] = lastRequest(client);
+    expect(body.operation.data[0].pages).toHaveLength(2);
+    expect(body.operation.data[0].pages[0].name).toBe('Summary');
+    expect(body.operation.data[0].pages[1].name).toBe('NPCs');
+  });
+
+  it('includes folder when provided', async () => {
+    const client = buildClient();
+    await client.createJournalEntry(
+      'Session 11 Recap',
+      [{ name: 'Summary', content: 'a' }],
+      VALID_FOLDER_ID,
+    );
+    const [, body] = lastRequest(client);
+    expect(body.operation.data[0].folder).toBe(VALID_FOLDER_ID);
+  });
+
+  it('rejects an empty pages array before emitting', async () => {
+    const client = buildClient();
+    await expect(client.createJournalEntry('Session 11 Recap', [])).rejects.toThrow(
+      /at least one page/,
+    );
+  });
+
+  it('rejects a malformed folder id before emitting', async () => {
+    const client = buildClient();
+    await expect(
+      client.createJournalEntry('Session 11 Recap', [{ name: 'Summary', content: 'a' }], 'short'),
+    ).rejects.toThrow(/Invalid folder/);
+  });
+
+  it('rejects writes when FOUNDRY_WRITE_ENABLED is false', async () => {
+    const client = buildClient({ writeEnabled: false });
+    await expect(
+      client.createJournalEntry('Session 11 Recap', [{ name: 'Summary', content: 'a' }]),
+    ).rejects.toThrow(/FOUNDRY_WRITE_ENABLED/);
+  });
+
+  it('rejects writes when the socket is not connected', async () => {
+    const client = buildClient({ connected: false });
+    await expect(
+      client.createJournalEntry('Session 11 Recap', [{ name: 'Summary', content: 'a' }]),
+    ).rejects.toThrow(/Socket\.IO connection/);
+  });
+});

--- a/src/tools/handlers/__tests__/journal-mutations.test.ts
+++ b/src/tools/handlers/__tests__/journal-mutations.test.ts
@@ -179,6 +179,7 @@ describe('FoundryClient journal mutations (modifyDocument)', () => {
                 name: 'Summary',
                 type: 'text',
                 text: { content: '<p>The party arrived in Terris.</p>', format: 1 },
+                sort: 100000,
               },
             ],
           },
@@ -200,6 +201,19 @@ describe('FoundryClient journal mutations (modifyDocument)', () => {
     expect(body.operation.data[0].pages).toHaveLength(2);
     expect(body.operation.data[0].pages[0].name).toBe('Summary');
     expect(body.operation.data[0].pages[1].name).toBe('NPCs');
+  });
+
+  it('assigns ascending sort values so pages render in the supplied order', async () => {
+    const client = buildClient();
+    await client.createJournalEntry('Session 11 Recap', [
+      { name: 'Summary', content: 'a' },
+      { name: 'NPCs', content: 'b' },
+      { name: 'Loot', content: 'c' },
+    ]);
+    const [, body] = lastRequest(client);
+    expect(body.operation.data[0].pages.map((p: { sort: number }) => p.sort)).toEqual([
+      100000, 200000, 300000,
+    ]);
   });
 
   it('includes folder when provided', async () => {

--- a/src/tools/handlers/journal-mutations.ts
+++ b/src/tools/handlers/journal-mutations.ts
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Journal entry mutation tool handlers (create)
+ *
+ * WRITE operations — require FOUNDRY_WRITE_ENABLED=true and an active Socket.IO
+ * connection (mutations use the core `modifyDocument` protocol). `JournalEntry`
+ * is a top-level document, so unlike the actor-item mutations there is no
+ * parent to scope the write to.
+ */
+
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
+import type { FoundryClient } from '../../foundry/client.js';
+import type { JournalPageCreateSource } from '../../foundry/types.js';
+import { withToolError } from './utils.js';
+
+/**
+ * Handles creating a journal entry with one or more text pages.
+ */
+export async function handleCreateJournalEntry(
+  args: {
+    name: string;
+    pages: JournalPageCreateSource[];
+    folder?: string;
+  },
+  foundryClient: FoundryClient,
+) {
+  const { name, pages, folder } = args;
+
+  if (!name || typeof name !== 'string') {
+    throw new McpError(ErrorCode.InvalidParams, 'name is required and must be a string');
+  }
+  if (!Array.isArray(pages) || pages.length === 0) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      'pages is required and must contain at least one page',
+    );
+  }
+  for (const page of pages) {
+    if (
+      !page ||
+      typeof page !== 'object' ||
+      typeof page.name !== 'string' ||
+      typeof page.content !== 'string'
+    ) {
+      throw new McpError(ErrorCode.InvalidParams, 'each page requires a name and content string');
+    }
+  }
+
+  return withToolError('create journal entry', async () => {
+    const journal = await foundryClient.createJournalEntry(name, pages, folder);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `📓 **Journal Entry Created**
+**Name:** ${journal.name}
+**ID:** ${journal._id}
+**Pages:** ${journal.pages?.length ?? pages.length}`,
+        },
+      ],
+    };
+  });
+}

--- a/src/tools/router.ts
+++ b/src/tools/router.ts
@@ -5,7 +5,7 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { DiagnosticsClient } from '../diagnostics/client.js';
 import type { AttributePatch, FoundryClient } from '../foundry/client.js';
-import type { ActorItemCreateSource } from '../foundry/types.js';
+import type { ActorItemCreateSource, JournalPageCreateSource } from '../foundry/types.js';
 import type { DiagnosticSystem } from '../utils/diagnostics.js';
 import { logger } from '../utils/logger.js';
 import type { ToolContext, ToolResult } from './base.js';
@@ -36,6 +36,7 @@ import {
   handleUpdateActorItem,
 } from './handlers/item-mutations.js';
 import { handleSearchItems } from './handlers/items.js';
+import { handleCreateJournalEntry } from './handlers/journal-mutations.js';
 import { handleGetJournal, handleSearchJournals } from './handlers/journals.js';
 import { handleReadResource } from './handlers/resources.js';
 import { handleGetSceneInfo } from './handlers/scenes.js';
@@ -246,6 +247,20 @@ export async function routeToolRequest(
         throw new Error('Missing required parameter: journalId');
       }
       return handleGetJournal(args as { journalId: string }, foundryClient);
+
+    // Journal mutation tools (WRITE) — Socket.IO modifyDocument protocol
+    // (foundryClient); require FOUNDRY_WRITE_ENABLED=true + a GM user.
+    case 'create_journal_entry':
+      if (!('name' in args) || typeof args.name !== 'string') {
+        throw new Error('Missing required parameter: name');
+      }
+      if (!('pages' in args) || !Array.isArray(args.pages)) {
+        throw new Error('Missing required parameter: pages');
+      }
+      return handleCreateJournalEntry(
+        args as { name: string; pages: JournalPageCreateSource[]; folder?: string },
+        foundryClient,
+      );
 
     // World tools
     case 'search_world':


### PR DESCRIPTION
## Summary

Carries @mike-marshall0164's commit from #202 unchanged and adds the review fixes on top. **This is an alternative merge path for #202, not a replacement** — if you'd rather have the fixes land in the contributor's own branch, the follow-up commit here cherry-picks cleanly onto `feat/journal-entry-create` and this PR can be closed.

`14e231a` (theirs) adds `create_journal_entry` — the one document type the write surface was missing — following the existing `modifyDocument` Socket.IO protocol.

## Review fixes added on top

- **Explicit page `sort`.** Pages were created without a `sort`, leaving every sibling at Foundry's default `0`. Render order then falls back to incidental collection insertion order, and Foundry has no gap to slot a UI-created sibling into afterwards. Pages now get ascending multiples of `SORT_INTEGER_DENSITY` (100000), matching what the Foundry UI does. Covered by a new unit test (329 total, was 328).
- **README.** `create_journal_entry` added to the Write Operations list, which had every other write tool.
- **Tool description.** Notes that a created entry is GM-only until ownership is granted, and that it won't appear in `search_journals`/`get_journal` until `refresh_world_data` runs. Both are follow-ups (#204, #205), but the caller should know now.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test` — 329/329 pass
- [x] `bunx biome check src/` — no new warnings (the 11 reported are pre-existing, `src/utils/cache.ts` et al)
- [ ] Not smoke-tested against a live world. The thing worth confirming manually before merge is that Foundry's server-side create materializes the embedded `pages` array from the `modifyDocument` payload — the integration tier is still gated on `FOUNDRY_*` secrets (#140).

## CI

Two checks are red, both failing on `main` at the same commit and unrelated to this diff:

- **Dependency Audit** — `bun audit` reports 20 transitive advisories (`socket.io-parser`, `fast-uri` via `ajv`, `hono` via `@modelcontextprotocol/sdk`). Red on `main` since 2026-07-27.
- **Integration Tests** — `.env.integration` / `FOUNDRY_LICENSE_KEY` absent on the runner, the #140 gating. Red on `main` throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GBRpAbnS59jhRiR4RfkdBi