### PR TITLE
fix(auth): send the Foundry session as a Cookie header, and load .env before config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,9 @@ jobs:
     - name: Startup smoke test
       run: bun run smoke
 
+    - name: Dotenv load-order smoke test
+      run: bun run smoke:dotenv
+
     - name: Pack smoke test
       run: bun run smoke:pack
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "smoke": "node scripts/smoke-test.js",
+    "smoke:dotenv": "node scripts/smoke-dotenv.js",
     "smoke:pack": "node scripts/smoke-pack.js",
     "test": "vitest run",
     "test:watch": "vitest --watch",

--- a/scripts/smoke-dotenv.js
+++ b/scripts/smoke-dotenv.js
@@ -1,0 +1,156 @@
+#!/usr/bin/env node
+
+/**
+ * Regression smoke test for dotenv load ordering (issue #206).
+ *
+ * The documented configuration path — a `.env` file in the working directory —
+ * was silently dead. `src/index.ts` called `dotenv.config()` in its module
+ * body, but ESM evaluates every imported module *before* that body runs, and
+ * `utils/logger.ts` builds its logger at module scope from `config.logLevel`,
+ * which resolves the whole configuration eagerly. Configuration was therefore
+ * validated against a `process.env` that had never seen the `.env` file, and
+ * startup died with "Configuration validation failed" while pointing the user
+ * at the very file it had ignored.
+ *
+ * This test spawns the built server from a scratch directory whose only source
+ * of configuration is a `.env` file, with every FOUNDRY_* variable stripped
+ * from the inherited environment, and asserts the startup banner appears.
+ *
+ * A unit test cannot cover this: the defect is in module evaluation order in a
+ * real process, which any test that imports the modules has already perturbed.
+ *
+ * Exits 0 on success, non-zero on any failure.
+ */
+
+import { spawn } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..');
+const serverPath = join(repoRoot, 'dist', 'index.js');
+
+const BANNER = '🎲 FoundryVTT MCP Server starting...';
+const CONFIG_FAILURE = 'Configuration validation failed';
+const STARTUP_TIMEOUT_MS = 5000;
+const SIGKILL_GRACE_MS = 2000;
+
+if (!existsSync(serverPath)) {
+  console.error(`❌ Built server not found at ${serverPath}`);
+  console.error('   Run `bun run build` before invoking the smoke test.');
+  process.exit(2);
+}
+
+// Scratch working directory whose only configuration is the dotenv file.
+const workDir = mkdtempSync(join(tmpdir(), 'fvtt-mcp-dotenv-'));
+writeFileSync(
+  join(workDir, '.env'),
+  [
+    // Port 1 is unbindable, so the connection attempt fails fast — well after
+    // the banner this test waits for.
+    'FOUNDRY_URL=http://127.0.0.1:1',
+    'FOUNDRY_USERNAME=dotenv-smoke',
+    'FOUNDRY_PASSWORD=dotenv-smoke',
+    'LOG_LEVEL=error',
+    '',
+  ].join('\n'),
+);
+
+// Strip every FOUNDRY_*/LOG_LEVEL variable so the dotenv file is the sole
+// source of configuration — an inherited FOUNDRY_URL would make this pass
+// regardless of whether the file was read.
+const childEnv = Object.fromEntries(
+  Object.entries(process.env).filter(
+    ([key]) => !key.startsWith('FOUNDRY_') && key !== 'LOG_LEVEL',
+  ),
+);
+
+const child = spawn('node', [serverPath], {
+  cwd: workDir,
+  env: childEnv,
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+
+let stderr = '';
+let stdout = '';
+let resolved = false;
+
+child.stdout.on('data', (chunk) => {
+  stdout += chunk.toString();
+});
+
+child.stderr.on('data', (chunk) => {
+  stderr += chunk.toString();
+  if (resolved) return;
+  if (stderr.includes(CONFIG_FAILURE)) {
+    finish(false, 'configuration validation failed — the .env file was not loaded in time');
+    return;
+  }
+  if (stderr.includes(BANNER)) {
+    finish(true, 'server started with configuration sourced from .env');
+  }
+});
+
+child.on('exit', (code, signal) => {
+  if (resolved) return;
+  finish(false, `server exited prematurely (code=${code}, signal=${signal})`);
+});
+
+child.on('error', (err) => {
+  if (resolved) return;
+  finish(false, `failed to spawn server: ${err.message}`);
+});
+
+const timeout = setTimeout(() => {
+  if (resolved) return;
+  finish(false, `timed out after ${STARTUP_TIMEOUT_MS}ms waiting for banner`);
+}, STARTUP_TIMEOUT_MS);
+
+function finish(success, message) {
+  if (resolved) return;
+  resolved = true;
+  clearTimeout(timeout);
+
+  if (success) {
+    console.log(`✅ dotenv smoke test passed: ${message}`);
+    terminate(0);
+    return;
+  }
+
+  console.error(`❌ dotenv smoke test failed: ${message}`);
+  if (stderr) {
+    console.error('--- stderr ---');
+    console.error(stderr);
+  }
+  if (stdout) {
+    console.error('--- stdout ---');
+    console.error(stdout);
+  }
+  terminate(1);
+}
+
+function terminate(exitCode) {
+  const cleanup = () => {
+    rmSync(workDir, { recursive: true, force: true });
+    process.exit(exitCode);
+  };
+
+  if (child.exitCode !== null || child.signalCode !== null) {
+    cleanup();
+    return;
+  }
+
+  child.kill('SIGTERM');
+  const killTimer = setTimeout(() => {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL');
+    }
+  }, SIGKILL_GRACE_MS);
+
+  child.once('exit', () => {
+    clearTimeout(killTimer);
+    cleanup();
+  });
+}

--- a/scripts/test-connection.ts
+++ b/scripts/test-connection.ts
@@ -5,13 +5,12 @@
  * Run with: npm run test-connection
  */
 
+// Must precede every other import: see src/load-env.ts (#206).
+import '../src/load-env.js';
 import axios from 'axios';
-import dotenv from 'dotenv';
 import { FoundryClient } from '../src/foundry/client.js';
 import { config } from '../src/config/index.js';
 import { logger } from '../src/utils/logger.js';
-
-dotenv.config({ quiet: true });
 
 /**
  * True when a REST-mode request failed because the target's REST module does

--- a/src/foundry/__tests__/auth.test.ts
+++ b/src/foundry/__tests__/auth.test.ts
@@ -27,7 +27,7 @@ vi.mock('../../utils/logger.js', () => ({
   },
 }));
 
-const { authenticateFoundry } = await import('../auth.js');
+const { authenticateFoundry, sessionSocketOptions } = await import('../auth.js');
 const { logger } = await import('../../utils/logger.js');
 
 const mockAxios = vi.mocked(axios);
@@ -219,5 +219,103 @@ describe('authenticateFoundry — warn-and-continue (CN-7 analogue)', () => {
     await expect(authenticateFoundry('not a real url', 'abc123DEF456ghij', 'pw')).rejects.toThrow();
 
     expect(logger.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('authenticateFoundry — session cookie on the Socket.IO handshake (#206)', () => {
+  /**
+   * FoundryVTT resolves the session from the `session` cookie on the handshake
+   * request. Sending it only as a query parameter leaves the socket anonymous:
+   * it connects, `connect_error` never fires, and `getJoinData` is simply never
+   * answered — so the only symptom is the 10s timeout in resolveUserId.
+   */
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockJoinCookieResponse();
+    mockJoinPostSuccess();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('passes the session as a Cookie header, not only as a query param', async () => {
+    const { socket } = buildMockSocket([{ _id: 'resolvedDocId123', name: 'Gamemaster' }]);
+    mockIo.mockReturnValue(socket);
+
+    await authenticateFoundry('http://localhost:30000', 'Gamemaster', 'pw');
+
+    expect(mockIo).toHaveBeenCalledWith(
+      'http://localhost:30000',
+      expect.objectContaining({
+        extraHeaders: { Cookie: 'session=test-session-cookie' },
+        query: { session: 'test-session-cookie' },
+      }),
+    );
+  });
+});
+
+describe('sessionSocketOptions (#206)', () => {
+  it('carries the session in both the Cookie header and the query param', () => {
+    expect(sessionSocketOptions('abc123')).toEqual({
+      transports: ['websocket'],
+      query: { session: 'abc123' },
+      extraHeaders: { Cookie: 'session=abc123' },
+    });
+  });
+});
+
+describe('authenticateFoundry — rejected /join is reported, not thrown raw (#206)', () => {
+  /**
+   * FoundryVTT v13+ answers a rejected /join with HTTP 401 and a plain-text
+   * i18n key body (e.g. "JOIN.ErrorInvalidPassword"). Without 401 in
+   * validateStatus axios throws first, surfacing a bare
+   * "Request failed with status code 401" that says nothing about the cause.
+   */
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockJoinCookieResponse();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('surfaces FoundryVTT’s plain-text 401 body in the error message', async () => {
+    mockAxios.post = vi.fn().mockResolvedValue({
+      status: 401,
+      data: 'JOIN.ErrorInvalidPassword',
+    });
+
+    await expect(
+      authenticateFoundry('http://localhost:30000', 'abc123DEF456ghij', 'wrong'),
+    ).rejects.toThrow('FoundryVTT authentication failed (HTTP 401): JOIN.ErrorInvalidPassword');
+  });
+
+  it('accepts 401 as a readable status rather than letting axios throw', async () => {
+    mockAxios.post = vi.fn().mockResolvedValue({ status: 401, data: 'JOIN.ErrorInvalidPassword' });
+
+    await expect(
+      authenticateFoundry('http://localhost:30000', 'abc123DEF456ghij', 'wrong'),
+    ).rejects.toThrow();
+
+    const validateStatus = mockAxios.post.mock.calls[0]?.[2]?.validateStatus;
+    expect(validateStatus?.(401)).toBe(true);
+    expect(validateStatus?.(200)).toBe(true);
+    expect(validateStatus?.(302)).toBe(true);
+    expect(validateStatus?.(500)).toBe(false);
+  });
+
+  it('still surfaces a JSON { message } body when the server sends one', async () => {
+    mockAxios.post = vi.fn().mockResolvedValue({
+      status: 200,
+      data: { status: 'failed', message: 'You may not join this world' },
+    });
+
+    await expect(
+      authenticateFoundry('http://localhost:30000', 'abc123DEF456ghij', 'pw'),
+    ).rejects.toThrow('FoundryVTT authentication failed (HTTP 200): You may not join this world');
   });
 });

--- a/src/foundry/__tests__/client.test.ts
+++ b/src/foundry/__tests__/client.test.ts
@@ -8,6 +8,13 @@ vi.mock('../auth.js', () => ({
   authenticateFoundry: vi
     .fn()
     .mockResolvedValue({ session: 'test-session', userId: 'test-user-id' }),
+  // Real implementation — connectAndLoadWorld's handshake options are the
+  // subject of the #206 regression test below.
+  sessionSocketOptions: (session: string) => ({
+    transports: ['websocket'],
+    query: { session },
+    extraHeaders: { Cookie: `session=${session}` },
+  }),
 }));
 vi.mock('../../utils/logger.js', () => ({
   logger: {

--- a/src/foundry/auth.ts
+++ b/src/foundry/auth.ts
@@ -9,8 +9,30 @@
  */
 
 import axios from 'axios';
+import type { ManagerOptions, SocketOptions } from 'socket.io-client';
 import { io } from 'socket.io-client';
 import { logger } from '../utils/logger.js';
+
+/**
+ * Socket.IO connection options carrying a FoundryVTT session.
+ *
+ * FoundryVTT resolves the session from the `session` **cookie** on the
+ * handshake request; the `session` query parameter alone leaves the socket
+ * anonymous. An anonymous socket still connects at the transport level — it
+ * simply never answers `getJoinData` and emits `session` as `null` — so the
+ * only symptom is a bare timeout with no `connect_error` (#206).
+ *
+ * `extraHeaders` is honoured by socket.io-client in Node.js for both the
+ * WebSocket and polling handshakes; the query parameter is kept for servers
+ * that read it.
+ */
+export function sessionSocketOptions(session: string): Partial<ManagerOptions & SocketOptions> {
+  return {
+    transports: ['websocket'],
+    query: { session },
+    extraHeaders: { Cookie: `session=${session}` },
+  };
+}
 
 /**
  * Extracts the session cookie value from a GET /join response.
@@ -54,10 +76,7 @@ async function resolveUserId(baseUrl: string, user: string, session: string): Pr
   logger.debug('Resolving display name to document _id', { displayName: user });
 
   return new Promise((resolve, reject) => {
-    const socket = io(baseUrl, {
-      transports: ['websocket'],
-      query: { session },
-    });
+    const socket = io(baseUrl, sessionSocketOptions(session));
 
     const cleanup = () => {
       socket.off('session', onSession);
@@ -152,14 +171,23 @@ export async function authenticateFoundry(
         'Content-Type': 'application/json',
         Cookie: `session=${session}`,
       },
-      // Accept 200 (success JSON) and 302 (redirect to /game on success)
-      validateStatus: (status) => status === 200 || status === 302,
+      // Accept 200 (success JSON), 302 (redirect to /game on success) and 401
+      // (bad password). 401 carries FoundryVTT's own explanation in the body;
+      // letting axios throw on it would surface a bare
+      // "Request failed with status code 401" instead (#206).
+      validateStatus: (status) => status === 200 || status === 302 || status === 401,
     },
   );
 
   if (joinRes.data?.status !== 'success' && joinRes.data?.redirect !== '/game') {
-    const msg = joinRes.data?.message || joinRes.data?.error || 'Unknown error';
-    throw new Error(`FoundryVTT authentication failed: ${msg}`);
+    // FoundryVTT v13+ answers a rejected /join with a plain-text i18n key
+    // (e.g. "JOIN.ErrorInvalidPassword") rather than a JSON error object.
+    const msg =
+      (typeof joinRes.data === 'string' && joinRes.data.trim()) ||
+      joinRes.data?.message ||
+      joinRes.data?.error ||
+      'Unknown error';
+    throw new Error(`FoundryVTT authentication failed (HTTP ${joinRes.status}): ${msg}`);
   }
 
   logger.info('FoundryVTT authentication successful', { userId });

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -9,7 +9,7 @@ import axios, { type AxiosInstance, type AxiosRequestConfig, type AxiosResponse 
 import { io, type Socket } from 'socket.io-client';
 import { z } from 'zod';
 import { logger } from '../utils/logger.js';
-import { authenticateFoundry } from './auth.js';
+import { authenticateFoundry, sessionSocketOptions } from './auth.js';
 import type {
   ActorAttributeUpdateResult,
   ActorItemCreateSource,
@@ -225,10 +225,7 @@ export class FoundryClient {
    */
   private connectAndLoadWorld(session: string): Promise<WorldData> {
     return new Promise((resolve, reject) => {
-      this.socket = io(this.config.baseUrl, {
-        transports: ['websocket'],
-        query: { session },
-      });
+      this.socket = io(this.config.baseUrl, sessionSocketOptions(session));
 
       const cleanup = () => {
         this.socket?.off('session', onSession);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@
  * @see {@link https://foundryvtt.com/} FoundryVTT Virtual Tabletop
  */
 
+// Must precede every other import: see src/load-env.ts (#206).
+import './load-env.js';
 import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
@@ -27,7 +29,6 @@ import {
   McpError,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import dotenv from 'dotenv';
 import { config } from './config/index.js';
 import { DiagnosticsClient } from './diagnostics/client.js';
 import { FoundryClient, type FoundryClientConfig } from './foundry/client.js';
@@ -39,9 +40,6 @@ import {
 } from './tools/index.js';
 import { DiagnosticSystem } from './utils/diagnostics.js';
 import { logger } from './utils/logger.js';
-
-// Load environment variables
-dotenv.config({ quiet: true });
 
 /**
  * Main FoundryVTT MCP Server class that handles all communication

--- a/src/load-env.ts
+++ b/src/load-env.ts
@@ -1,0 +1,15 @@
+/**
+ * Loads `.env` into `process.env` as an import side effect.
+ *
+ * Import this **first**, before any module that reads configuration. ESM
+ * evaluates a module's dependencies before its own body, so calling
+ * `dotenv.config()` in an entrypoint's body runs *after* every imported module
+ * has already been evaluated. `utils/logger.ts` builds its logger at module
+ * scope from `config.logLevel`, which resolves the whole config eagerly — so
+ * the entrypoint-body form validated configuration before `.env` was read, and
+ * a `.env` in the working directory had no effect at all (#206).
+ */
+
+import dotenv from 'dotenv';
+
+dotenv.config({ quiet: true });


### PR DESCRIPTION
## What

Two independent startup-blocking defects reported in #206, both reproduced and fixed:

1. **The Foundry session was sent only as a Socket.IO query parameter, never as a `Cookie` header.** Foundry resolves the session from the cookie, so both sockets connected as anonymous users.
2. **`.env` was documented but never actually loaded**, so the file the error message told users to check had no effect.

## Why

**The session cookie.** An anonymous Foundry socket still connects at the transport level — `connect_error` never fires and `socket.connected` is `true` — it simply never answers `getJoinData`. The only symptom is `Timeout resolving user ID via getJoinData` after 10 s, which points nowhere near authentication. Worse, the failure is identical whether the username is correct, misspelled, or nonexistent, because the lookup that would report "user not found" is the call that never returns.

Both `io()` calls now go through `sessionSocketOptions()`, so the two handshakes cannot drift apart again.

**The `.env` load order.** `src/index.ts` called `dotenv.config()` in its module body. ESM evaluates every imported module *before* that body runs, and `utils/logger.ts` builds its logger at module scope from `config.logLevel`, which resolves the whole configuration eagerly. Configuration was therefore validated against a `process.env` that had never seen the file. The load moved to `src/load-env.ts`, imported first — a side-effect import is evaluated before the imports that follow it. `scripts/test-connection.ts` had the same defect and gets the same fix.

The reporter attributed this one to a missing `dotenv` dependency; `dotenv` was in fact present and imported since the initial commit. The cause was ordering, not absence.

**A rejected `/join` is now readable too.** Foundry v13+ answers with HTTP 401 and a plain-text i18n key body (`JOIN.ErrorInvalidPassword`) rather than JSON. `validateStatus` excluded 401, so axios threw on the status before that body could be read and a wrong password surfaced as a bare `Request failed with status code 401`. Same diagnosability class as the symptom above, so it is fixed here rather than deferred.

## Verification

Against a live FoundryVTT **14.365** world (`dnd5e` 5.3.3) — the same build as the report:

| Check | Before | After |
|---|---|---|
| `getJoinData` ack | 10 s expiry, no ack | ack in 35 ms, 8 users returned |
| `authenticateFoundry` | expires at step 2 | resolves the user, reaches `/join` |
| `client.connect()` | never reached | connected in ~2.9 s — 924 actors, 220 scenes, 978 items |
| Wrong password | `Request failed with status code 401` | `FoundryVTT authentication failed (HTTP 401): JOIN.ErrorInvalidPassword` |
| `.env`-only startup | `Configuration validation failed` | server starts |

Each fix was control-tested by reverting it: removing the `Cookie` header reproduces `Timeout resolving user ID via getJoinData` exactly, and the pre-fix entrypoint fails the new dotenv smoke test with the reported configuration error.

## Tests

- `src/foundry/__tests__/auth.test.ts` — the handshake carries the session as a `Cookie` header, `sessionSocketOptions()` shape, and the three 401-reporting cases.
- `scripts/smoke-dotenv.js` (`bun run smoke:dotenv`, wired into CI) — starts the built server from a scratch directory whose only configuration is a `.env` file, with every `FOUNDRY_*` variable stripped from the inherited environment. A unit test cannot cover this: the defect is in module evaluation order in a real process, which any test importing the modules has already perturbed.

`just qa` green — 367 tests, 26 files.

Closes #206
