### PR TITLE
Close open issues: docs CI parity (#182), worktree gitignore (#184), tool-surface write-safety wording (#185)

### DIFF
--- a/.github/DOCUMENTATION.md
+++ b/.github/DOCUMENTATION.md
@@ -8,6 +8,7 @@ This repository includes several GitHub Actions workflows for automated document
 **Recommended for public repositories**
 
 - ✅ Deploys to GitHub Pages automatically
+- ✅ Validates the docs build on pull requests (build only, no deploy)
 - ✅ Clean URLs (e.g., `https://username.github.io/repo/`)
 - ✅ Fast CDN delivery
 - ✅ Automatic HTTPS
@@ -16,7 +17,16 @@ This repository includes several GitHub Actions workflows for automated document
 **Setup:**
 1. Go to Repository Settings → Pages
 2. Set Source to "GitHub Actions"
-3. The workflow will deploy on every push to main
+3. The workflow deploys on every push to main (and on manual `workflow_dispatch`
+   runs). Pull requests run the `build` job only — they check out, install, run
+   TypeDoc and `bun run docs:check`, then stop; the Pages steps and the `deploy`
+   job are skipped.
+
+> **Branch protection:** do not add this workflow's `build` or `deploy` job as a
+> required status check. Both `on:` triggers are `paths`-filtered, so a PR that
+> touches nothing under `src/**`, `README.md`, `typedoc.json`, `package.json`, or
+> this workflow never reports a status at all and a required check would wait
+> forever. `deploy` is additionally *skipped* on pull requests by design.
 
 ### 2. `update-docs.yml` - Repository Commit
 **Works for all repositories (public/private)**
@@ -112,8 +122,17 @@ docs/                      # Generated documentation
 
 ## 🔍 Troubleshooting
 
+### Pull Request Run Shows Skipped Steps
+This is expected. On a `pull_request` event, `Setup Pages`, `Upload
+documentation artifact`, and the whole `deploy` job are skipped — a PR
+validates the docs build and never deploys. A skipped job does not fail the
+workflow, so the run is green on `build` alone.
+
 ### Documentation Not Updating
-1. Check that workflows have proper permissions
+1. Check that workflows have proper permissions. `docs.yml` scopes them per job:
+   `build` gets `contents: read` + `pages: write` (needed by
+   `actions/configure-pages`), `deploy` gets `contents: read` + `pages: write` +
+   `id-token: write` (needed by `actions/deploy-pages`).
 2. Ensure the triggering paths match your changes
 3. Review workflow logs in the Actions tab
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,24 +11,38 @@ on:
       - 'package.json'
       - '.github/workflows/docs.yml'
 
+  # Validate the docs build on pull requests (build only, no deploy)
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'src/**'
+      - 'README.md'
+      - 'typedoc.json'
+      - 'package.json'
+      - '.github/workflows/docs.yml'
+
   # Allow manual trigger
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Default to least privilege; the deploy job opts into the Pages permissions it needs
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued
+# Deploys share the single "pages" group (never cancelled); PR validation runs get
+# their own per-ref group so they neither queue behind nor cancel a Pages deployment
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: ${{ github.event_name == 'pull_request' && format('docs-pr-{0}', github.ref) || 'pages' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Build documentation
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # actions/configure-pages calls the Pages REST API, so the build job needs
+      # the Pages scope on the events where that step actually runs.
+      pages: write
 
     steps:
       - name: Checkout repository
@@ -50,21 +64,38 @@ jobs:
             --skipErrorChecking \
             --cleanOutputDir
 
+      # Docs gate that contributors also run locally (`just docs-check` /
+      # `bun run docs:check`). The deploy build above uses --skipErrorChecking,
+      # so on its own it would only catch a deleted or renamed entry point.
+      - name: Check documentation build (typedoc, no emit)
+        if: github.event_name == 'pull_request'
+        run: bun run docs:check
+
+      # Pages-specific steps only run when we are actually going to deploy.
+      # configure-pages hits the Pages API and needs the pages scope, which a
+      # pull_request GITHUB_TOKEN (especially from a fork) does not have.
       - name: Setup Pages
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/configure-pages@v6
 
       - name: Upload documentation artifact
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-pages-artifact@v5
         with:
           path: './docs'
 
-  # Deploy to GitHub Pages
+  # Deploy to GitHub Pages (push to main / manual runs only — never on pull requests)
   deploy:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
 
     steps:
       - name: Deploy to GitHub Pages

--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,9 @@ temp/
 # Claude local settings (user-specific)
 .claude/settings.local.json
 
+# Claude agent worktrees (transient, per-session state)
+.claude/worktrees/
+
 # Blueprint work orders (task-specific, may contain sensitive details)
 docs/blueprint/work-orders/
 *.swp

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Ask your AI assistant things like:
 - `get_scene_info` — current scene details
 - `search_journals` — search notes and handouts
 - `get_journal` — retrieve a specific journal entry
-- `get_users` — list online users and their status
+- `get_users` — list users, roles, and online status as of the last world-data load
 - `get_combat_state` — combat state and initiative order
 - `get_chat_messages` — recent chat history
 
@@ -154,6 +154,9 @@ Game-state mutations are **disabled by default**. They use the Socket.IO
 `modifyDocument` protocol over an authenticated session, and the connected user
 needs GM/owner permission. Set `FOUNDRY_WRITE_ENABLED=true` to enable them.
 
+- `start_combat` — begin a new encounter, seeding combatants from tokens (does
+  not check for an existing combat — calling it during an active one creates a
+  second encounter)
 - `next_turn` — advance the active combat to the next turn (wraps to the next round)
 - `end_combat` — end (delete) the active combat encounter
 - `set_initiative` — set a combatant's initiative in the active combat
@@ -174,20 +177,20 @@ needs GM/owner permission. Set `FOUNDRY_WRITE_ENABLED=true` to enable them.
 
 ### Game Mechanics
 
-- `roll_dice` — roll dice with any formula
-- `lookup_rule` — game rules and spell descriptions
+- `roll_dice` — roll dice; each term must be written `NdS` with any modifier attached directly to it
+- `lookup_rule` — **stub**: returns a templated placeholder, consults no rules source
 
 ### Content Generation
 
-- `generate_npc` — create random NPCs
-- `generate_loot` — create treasure appropriate for level
+- `generate_npc` — generate NPC text (not written to the world)
+- `generate_loot` — generate treasure text for a level (not written to the world)
 
 ### Diagnostics (requires REST API module)
 
 - `get_recent_logs` — retrieve filtered FoundryVTT logs
-- `search_logs` — search logs with regex patterns
-- `get_system_health` — server performance and health metrics
-- `diagnose_errors` — analyze errors with troubleshooting suggestions
+- `search_logs` — search logs by pattern (matched entries are not returned yet; reports 0 results)
+- `get_system_health` — overall server health status (the resource-metric lines always read "N/A")
+- `diagnose_errors` — **stub**: returns a fixed "no errors detected" summary
 - `get_health_status` — comprehensive health diagnostics
 
 ## Available Resources

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -108,9 +108,9 @@ All features work out of the box with username/password authentication:
 Installing the **Foundry Local REST API** module and setting `FOUNDRY_API_KEY` enables 5 server monitoring tools:
 
 - `get_recent_logs` - Retrieve filtered FoundryVTT logs
-- `search_logs` - Search logs with regex patterns
-- `get_system_health` - Server performance and health metrics
-- `diagnose_errors` - Error analysis with troubleshooting suggestions
+- `search_logs` - Search logs by pattern (matched entries are not returned yet; reports 0 results)
+- `get_system_health` - Overall server health status (the resource-metric lines always read "N/A")
+- `diagnose_errors` - **stub**: returns a fixed "no errors detected" summary
 - `get_health_status` - Comprehensive health diagnostics
 
 To enable:

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -449,20 +449,21 @@ export class FoundryClient {
   }
 
   /**
-   * Patches attributes on an actor's `system` object (#143). WRITE — REST required.
+   * Patches attributes on an actor's `system` object (#143). WRITE — Socket.IO.
    *
    * `patch` keys are dot-paths into `actor.system` (e.g. `attributes.hp.value`,
-   * `currency.gp`, `spells.spell1.value`, `attributes.exhaustion`). The patch is
-   * expanded into a nested object and sent as `PUT /api/actors/:actorId` with the
-   * body `{ system: <expanded patch> }` — matching FoundryVTT's own document model
-   * (`Actor#update`).
+   * `currency.gp`, `spells.spell1.value`, `attributes.exhaustion`). Each key is
+   * prefixed with `system.` and sent through the Socket.IO `modifyDocument`
+   * write protocol as an `Actor` `update` — matching FoundryVTT's own document
+   * model (`Actor#update`). No REST call and no `apiKey` are involved.
    *
    * Client-side validation, using the actor's current data, rejects:
    *  - HP value exceeding `max + temp`,
    *  - spell-slot value exceeding its `max`,
    *  - exhaustion outside `0–10` (2024 rules) or `0–6` (2014 rules).
    *
-   * @throws if `apiKey` is unset, the id is malformed, the actor/path is missing,
+   * @throws via `assertWriteable()` if `writeEnabled` is false or the socket
+   *   is not connected; also if the id is malformed, the actor/path is missing,
    *   or a validation rule is violated.
    */
   async updateActorAttribute(

--- a/src/tools/__tests__/registry.test.ts
+++ b/src/tools/__tests__/registry.test.ts
@@ -7,6 +7,7 @@ import type { DiagnosticsClient } from '../../diagnostics/client.js';
 import type { FoundryClient } from '../../foundry/client.js';
 import type { DiagnosticSystem } from '../../utils/diagnostics.js';
 import type { ToolContext } from '../base.js';
+import { getAllTools } from '../definitions.js';
 import { RollDiceTool } from '../handlers/dice.js';
 import { toolRegistry } from '../registry.js';
 
@@ -45,6 +46,16 @@ describe('Tool Registry', () => {
     it('should get tool names', () => {
       const names = toolRegistry.getToolNames();
       expect(names).toContain('roll_dice');
+    });
+
+    // The registry class executes roll_dice while getAllTools() is what the
+    // server lists, so a drifted description would be invisible at runtime.
+    it('should describe roll_dice identically in the registry and in getAllTools()', () => {
+      const listed = getAllTools().find((t) => t.name === 'roll_dice');
+      const registered = toolRegistry.getToolDefinitions().find((d) => d.name === 'roll_dice');
+
+      expect(listed?.description).toBeDefined();
+      expect(registered?.description).toBe(listed?.description);
     });
   });
 

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -6,12 +6,40 @@
  */
 
 /**
+ * Shared write-safety clause appended to every mutation tool description.
+ *
+ * Both halves are enforced in code by `assertWriteable()`
+ * (`src/foundry/client.ts`): the `FOUNDRY_WRITE_ENABLED` opt-in (default
+ * `false`, see `src/config/index.ts`) and a live authenticated Socket.IO
+ * session. Foundry itself enforces the GM/owner permission (ADR-010).
+ */
+const WRITE_GATE =
+  'WRITE: mutates the live world. Requires FOUNDRY_WRITE_ENABLED=true (default false) and an active Socket.IO connection, and is refused otherwise; Foundry additionally enforces GM/owner permission on the document.';
+
+/**
+ * Extra clause for destructive tools (data removal that this server cannot undo).
+ */
+const CONFIRM_FIRST =
+  'DESTRUCTIVE and not undoable from this server: confirm the exact target with the user before calling.';
+
+/**
+ * Canonical `roll_dice` description.
+ *
+ * Exported so `RollDiceTool` (`src/tools/handlers/dice.ts`) can reuse the exact
+ * same string instead of keeping a second copy that silently drifts: the
+ * registry class is what *executes* the tool while `getAllTools()` is what is
+ * *listed*, so a divergence would be invisible.
+ */
+export const ROLL_DICE_DESCRIPTION =
+  'Roll dice and return the total with a per-term breakdown. Write every term as NdS with any modifier attached directly to it ("1d20+5", "3d6", "2d6 + 1d4"); a count-less "d20", a modifier separated from its term by a space ("1d20 + 5"), a trailing bonus ("1d20+5+3") and parentheses are silently dropped from the total rather than rejected, so a loosely written formula returns a wrong number. Use when: the user asks for a check, save, attack, damage, or any random result.';
+
+/**
  * Dice rolling tool definitions
  */
 export const diceTools = [
   {
     name: 'roll_dice',
-    description: 'Roll dice using standard RPG notation (e.g., 1d20, 3d6+4)',
+    description: ROLL_DICE_DESCRIPTION,
     inputSchema: {
       type: 'object',
       properties: {
@@ -35,7 +63,8 @@ export const diceTools = [
 export const actorTools = [
   {
     name: 'search_actors',
-    description: 'Search for actors (characters, NPCs) in FoundryVTT',
+    description:
+      "Search actors (player characters, NPCs) by name, optionally filtered by type. Returns a summary line per match: name, type, level and current/max HP. Use when: checking whether an actor exists, or getting a quick roster with HP. Do not use when: you already have the actorId and want that actor's ability scores - use get_actor_details; or you need the actorId itself, which this tool does not print - read the foundry://actors resource, whose JSON lists up to the first 100 actors with their _id (not exhaustive in larger worlds).",
     inputSchema: {
       type: 'object',
       properties: {
@@ -57,7 +86,8 @@ export const actorTools = [
   },
   {
     name: 'get_actor_details',
-    description: 'Get detailed information about a specific actor',
+    description:
+      'Get details for one actor by id: type, level, current/max HP, AC and ability scores; no biography or description text is returned (the description line always reads "No description available."). Use when: you have an actorId and need its current HP or ability scores - notably as the read-before-write step for update_actor_attributes. Do not use when: you only have a name - run search_actors first; or you need the ids of items the actor owns, which this tool does not return (no tool in this server lists owned-item ids - ask the user for the itemId).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -81,11 +111,8 @@ export const actorMutationTools = [
   {
     name: 'update_actor_attributes',
     description:
-      "Update attributes on an actor's system data. The patch keys are dot-paths into actor.system " +
-      '(e.g. "attributes.hp.value", "attributes.hp.temp", "currency.gp", "resources.primary.value", ' +
-      '"spells.spell1.value", "attributes.exhaustion"). Returns the post-update value for every patched ' +
-      'path. Validates HP <= max + temp, spell slots <= max, and exhaustion within 0-10 (2024) or 0-6 (2014). ' +
-      'Requires FOUNDRY_WRITE_ENABLED=true and an active Socket.IO connection.',
+      'Update fields on an actor\'s system data. Patch keys are dot-paths into actor.system (e.g. "attributes.hp.value", "attributes.hp.temp", "currency.gp", "resources.primary.value", "spells.spell1.value", "attributes.exhaustion") and values are absolute target values, never relative deltas. Validates HP <= max + temp, spell slots <= max, and exhaustion within 0-10 (2024) or 0-6 (2014), and returns the post-update value for every patched path. Use when: applying damage or healing, spending a spell slot or resource, or adjusting currency on a known actorId. Do not use when: changing an item the actor owns (use update_actor_item) or only reading current values (use get_actor_details). ' +
+      WRITE_GATE,
     inputSchema: {
       type: 'object',
       properties: {
@@ -114,7 +141,8 @@ export const actorMutationTools = [
 export const itemTools = [
   {
     name: 'search_items',
-    description: 'Search for items in FoundryVTT',
+    description:
+      'Search item documents in the world by name, optionally filtered by type. Returns name, type and rarity per match (rarity shows "Common" when the system records none); price is not available and always prints "Unknown price", and the rarity filter is ignored unless the REST API module is configured (FOUNDRY_API_KEY). Item ids are not printed - read the foundry://items resource, whose JSON lists up to the first 100 items with their _id (not exhaustive in larger worlds). Use when: checking whether an item exists in the world. Do not use when: searching compendium packs (use search_compendium) or listing what one actor carries (this searches world items, not owned items).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -128,7 +156,8 @@ export const itemTools = [
         },
         rarity: {
           type: 'string',
-          description: 'Item rarity filter (common, uncommon, rare, etc.)',
+          description:
+            'Item rarity filter (common, uncommon, rare, etc.). Applied only in REST API mode (FOUNDRY_API_KEY); ignored on the default Socket.IO path.',
         },
         limit: {
           type: 'number',
@@ -147,7 +176,7 @@ export const compendiumTools = [
   {
     name: 'search_compendium',
     description:
-      'Search FoundryVTT compendium packs by name and metadata. Searches all enabled compendiums by default; the compendiumId filter scopes to one pack. Requires the REST API module (FOUNDRY_API_KEY).',
+      'Search FoundryVTT compendium packs by name and metadata; searches all enabled packs unless compendiumId scopes it to one pack. Use when: looking up spells, monsters, or equipment that are not yet present in the world. Do not use when: the document already exists in the world - use search_items or search_world. Requires the REST API module (FOUNDRY_API_KEY); without it the search returns no results instead of failing.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -208,7 +237,8 @@ export const itemMutationTools = [
   {
     name: 'create_actor_item',
     description:
-      'Create an item on an actor from an inline item document (requires FOUNDRY_WRITE_ENABLED + active Socket.IO connection). Compendium-source create is not yet supported over Socket.IO (see issue #159). Canonical target: D&D 5e v4+ activity schema.',
+      'Create an item on an actor from an inline item document (type, name, system). Use when: adding a new weapon, spell, feature, or piece of equipment to a known actorId. Do not use when: editing an item the actor already owns - use update_actor_item. Replacing an item is not atomic: create the replacement first and delete the old one second, so a mid-sequence failure leaves the actor with a duplicate rather than nothing. Compendium-source create is not yet supported over Socket.IO (see issue #159). Canonical target: D&D 5e v4+ activity schema. ' +
+      WRITE_GATE,
     inputSchema: {
       type: 'object',
       properties: {
@@ -219,12 +249,13 @@ export const itemMutationTools = [
         source: {
           type: 'object',
           description:
-            'Item source: { type: "compendium", compendiumId, itemId } to copy a compendium entry, or { type: "inline", item: { type, name, system } } to create directly',
+            'Item source. Use { type: "inline", item: { type, name, system } } to create the item directly. The { type: "compendium", compendiumId, itemId } shape is accepted by the schema but rejected at call time - compendium-source create is not yet supported over Socket.IO.',
           properties: {
             type: {
               type: 'string',
               enum: ['compendium', 'inline'],
-              description: 'Source kind',
+              description:
+                'Source kind. Only "inline" is functional today; "compendium" is rejected at call time.',
             },
             compendiumId: {
               type: 'string',
@@ -248,7 +279,8 @@ export const itemMutationTools = [
   {
     name: 'update_actor_item',
     description:
-      "Apply a JSON merge patch to an item's system data on an actor (requires FOUNDRY_WRITE_ENABLED + active Socket.IO connection). Supports nested paths such as activities.{id}.consumption.targets. Canonical target: D&D 5e v4+ activity schema.",
+      "Apply a JSON merge patch to an item's system data on an actor: nested paths such as activities.{id}.consumption.targets are supported, values are absolute (arrays replace, null deletes). Use when: changing fields on an item the actor already owns, given actorId + itemId. Do not use when: adding a new item (create_actor_item) or removing one (delete_actor_item). Canonical target: D&D 5e v4+ activity schema. " +
+      WRITE_GATE,
     inputSchema: {
       type: 'object',
       properties: {
@@ -272,7 +304,10 @@ export const itemMutationTools = [
   {
     name: 'delete_actor_item',
     description:
-      'Delete an item owned by an actor (requires FOUNDRY_WRITE_ENABLED + active Socket.IO connection). Canonical target: D&D 5e v4+ activity schema.',
+      "Permanently remove an item owned by an actor. Use when: the user explicitly asks to delete or discard a specific owned item, and has given you the itemId - no tool in this server lists owned-item ids, so never guess one. Do not use when: only the item's data needs to change - use update_actor_item. In a replacement or migration flow, run create_actor_item first and this second: the two calls are not atomic, and failing after the delete loses the item. Echo the actorId and itemId back to the user and get their confirmation before calling. " +
+      CONFIRM_FIRST +
+      ' ' +
+      WRITE_GATE,
     inputSchema: {
       type: 'object',
       properties: {
@@ -296,7 +331,8 @@ export const itemMutationTools = [
 export const sceneTools = [
   {
     name: 'get_scene_info',
-    description: 'Get information about the current or specified scene',
+    description:
+      "Get details of the active scene, or of a specific scene by id: name, scene id, active/navigation flags, pixel dimensions, padding and lighting (global light, darkness); no description text is returned unless a module has set a description flag on the scene (the description line otherwise reads 'No description available.'). Use when: you need the sceneId or the scene's pixel extents. Do not use when: looking a scene up by name (use search_world), or you need grid size or token coordinates - this tool returns neither.",
     inputSchema: {
       type: 'object',
       properties: {
@@ -315,7 +351,8 @@ export const sceneTools = [
 export const generationTools = [
   {
     name: 'generate_npc',
-    description: 'Generate a random NPC with stats and background',
+    description:
+      'Generate a random NPC (name, race, class, HP, ability scores, background) as text. Use when: the user needs a throwaway NPC on the spot. Do not use when: the NPC must exist in FoundryVTT - this creates no documents, and the result still has to be entered into the world by hand.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -339,7 +376,8 @@ export const generationTools = [
   },
   {
     name: 'generate_loot',
-    description: 'Generate random loot for encounters',
+    description:
+      "Generate random treasure for an encounter as text. Only the currency amounts vary: they scale with the challenge rating, while the item list is fixed (a Healing Potion and a Silver Ring) and the treasureType argument is accepted but not used. Use when: the user wants a quick coin total for an encounter. Do not use when: the loot should end up in an actor's inventory - this creates no documents; use create_actor_item for that.",
     inputSchema: {
       type: 'object',
       properties: {
@@ -351,14 +389,16 @@ export const generationTools = [
         },
         treasureType: {
           type: 'string',
-          description: 'Type of treasure (hoard, individual, etc.)',
+          description:
+            'Type of treasure (hoard, individual, etc.). Accepted but not used - the generated result is the same whichever value is passed.',
         },
       },
     },
   },
   {
     name: 'lookup_rule',
-    description: 'Look up game rules and mechanics',
+    description:
+      'Stub: builds a templated placeholder from the query and consults no rules source, so the text it returns carries no rules content. No tool in this server looks rules up.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -382,7 +422,8 @@ export const generationTools = [
 export const diagnosticsTools = [
   {
     name: 'get_recent_logs',
-    description: 'Get recent log entries from FoundryVTT',
+    description:
+      'Get recent FoundryVTT server log entries, optionally filtered by level or since a timestamp. Use when: investigating an error or recent server behaviour. Do not use when: you have a specific term to look for - use search_logs. Requires the REST API module (FOUNDRY_API_KEY); fails without it.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -407,7 +448,8 @@ export const diagnosticsTools = [
   },
   {
     name: 'search_logs',
-    description: 'Search through FoundryVTT logs',
+    description:
+      'Search the FoundryVTT server logs for a query string. Use when: hunting a specific error message, stack trace, or module name. Do not use when: you just want the latest entries - use get_recent_logs. Note: the level and limit arguments are accepted but are not applied to the search, and matched entries are not rendered - the result reports 0 results and lists no entries whatever the log contains, so get_recent_logs is currently the only tool that returns log content. Requires the REST API module (FOUNDRY_API_KEY); fails without it.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -431,7 +473,8 @@ export const diagnosticsTools = [
   },
   {
     name: 'get_system_health',
-    description: 'Get system health and performance metrics',
+    description:
+      'Get the FoundryVTT server\'s overall health status (healthy, warning, or critical). That status is the only value reported: the output\'s CPU, memory, disk, uptime, connection and performance lines have no counterpart in the diagnostics response schema and always read "N/A". Use when: you want a single healthy/warning/critical verdict for the server. Do not use when: you also want connection and world status - use get_health_status. Requires the REST API module (FOUNDRY_API_KEY); fails without it.',
     inputSchema: {
       type: 'object',
       properties: {},
@@ -440,7 +483,7 @@ export const diagnosticsTools = [
   {
     name: 'diagnose_errors',
     description:
-      'Stub: returns raw logs without analysis. Full diagnostic logic is tracked in #133 and not yet implemented.',
+      'Stub: returns a fixed "no errors detected" summary regardless of input; real diagnostic logic is not implemented, so the summary reflects nothing about the server. For actual log content use get_recent_logs.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -453,7 +496,8 @@ export const diagnosticsTools = [
   },
   {
     name: 'get_health_status',
-    description: 'Get comprehensive health status of FoundryVTT server',
+    description:
+      'Get a combined health report: MCP-to-FoundryVTT connection state, world title/system/core version, and the server\'s health status. The connection line is the last known state - it is set when the client connects and cleared only by an explicit disconnect, not by a dropped socket, so it is not a live probe. Playtime always reports 0 hours, and the CPU, memory and uptime lines always read "N/A", as the underlying responses carry none of those values. Degrades gracefully - sections that need the REST API module (FOUNDRY_API_KEY) report as unavailable rather than failing. Use when: first checking which world is loaded and whether the server reports itself healthy.',
     inputSchema: {
       type: 'object',
       properties: {},
@@ -467,7 +511,8 @@ export const diagnosticsTools = [
 export const combatTools = [
   {
     name: 'get_combat_state',
-    description: 'Get the current active combat state including initiative order, HP, and AC',
+    description:
+      "Get the active combat encounter: initiative order with each combatant's name, initiative, HP and AC, plus the current round and which combatant is up. Use when: reporting whose turn it is, or checking whether a combat is already running before start_combat. Do not use when: you need a combatantId for set_initiative - this prints names and ordinals, not ids; read the foundry://combat resource, whose JSON includes each combatant's _id.",
     inputSchema: {
       type: 'object',
       properties: {},
@@ -486,9 +531,8 @@ export const combatMutationTools = [
   {
     name: 'next_turn',
     description:
-      'Advance the active combat to the next turn, wrapping to the next round after the last combatant. ' +
-      'When skipDefeated is true, defeated combatants are skipped. ' +
-      'Requires FOUNDRY_WRITE_ENABLED=true and an active Socket.IO connection.',
+      'Advance the active combat to the next turn, wrapping to the next round after the last combatant. When skipDefeated is true, defeated combatants are skipped. Use when: the current combatant has finished their turn. Do not use when: only reporting the turn order - use get_combat_state. ' +
+      WRITE_GATE,
     inputSchema: {
       type: 'object',
       properties: {
@@ -503,8 +547,10 @@ export const combatMutationTools = [
   {
     name: 'end_combat',
     description:
-      'End (delete) the active combat encounter. ' +
-      'Requires FOUNDRY_WRITE_ENABLED=true and an active Socket.IO connection.',
+      'End the active combat encounter by deleting its Combat document, discarding the initiative order and round count. Use when: the fight is over and the user asks to end the encounter. ' +
+      CONFIRM_FIRST +
+      ' ' +
+      WRITE_GATE,
     inputSchema: {
       type: 'object',
       properties: {},
@@ -513,8 +559,8 @@ export const combatMutationTools = [
   {
     name: 'set_initiative',
     description:
-      "Set a combatant's initiative in the active combat. " +
-      'Requires FOUNDRY_WRITE_ENABLED=true and an active Socket.IO connection.',
+      "Set a combatant's initiative in the active combat (or in combatId when given), reordering the turn order. Use when: an initiative roll needs to be recorded or corrected for a known combatantId. Do not use when: simply moving on to the next combatant - use next_turn. " +
+      WRITE_GATE,
     inputSchema: {
       type: 'object',
       properties: {
@@ -537,10 +583,8 @@ export const combatMutationTools = [
   {
     name: 'start_combat',
     description:
-      'Start a new combat encounter, seeding combatants from tokens. ' +
-      'Provide explicit tokenIds, or omit them to seed every token on the scene. ' +
-      'Defaults to the active scene when sceneId is omitted. ' +
-      'Requires FOUNDRY_WRITE_ENABLED=true and an active Socket.IO connection (GM permission).',
+      'Start a new combat encounter, seeding combatants from tokens: pass explicit tokenIds, or omit them to seed every token on the scene. Defaults to the active scene when sceneId is omitted. Use when: a fight begins and no combat is running. Do not use when: a combat is already active - check get_combat_state first, since this always creates an additional encounter. ' +
+      WRITE_GATE,
     inputSchema: {
       type: 'object',
       properties: {
@@ -570,9 +614,8 @@ export const tokenMutationTools = [
   {
     name: 'move_token',
     description:
-      'Move a token to new x/y pixel coordinates on its scene. ' +
-      'The token is located across scenes by id (optionally scoped with sceneId). ' +
-      'Requires FOUNDRY_WRITE_ENABLED=true and an active Socket.IO connection.',
+      "Move a token to new x/y pixel coordinates on its scene; the token is located across scenes by id, optionally scoped with sceneId. Coordinates are absolute pixels, not grid squares and not offsets. Use when: repositioning a token to a position the user has given you. Do not use when: you would have to guess the destination - no tool in this server reports a token's current position or the scene grid size, so ask the user for the target coordinates rather than inferring them. " +
+      WRITE_GATE,
     inputSchema: {
       type: 'object',
       properties: {
@@ -599,9 +642,9 @@ export const tokenMutationTools = [
   {
     name: 'apply_status_effect',
     description:
-      "Apply or remove a status condition (e.g. 'prone', 'stunned') on a token's actor. " +
-      'Set active=false to remove. Matches by status id, so re-applying or clearing-when-absent is a no-op. ' +
-      'Requires FOUNDRY_WRITE_ENABLED=true and an active Socket.IO connection.',
+      'Apply or remove a status condition (e.g. "prone", "stunned") on a token\'s actor. Set active=false to remove. Matches by status id, so re-applying or clearing-when-absent is a no-op. Use when: a condition is gained or lost. Do not use when: changing numeric state such as HP or exhaustion - use update_actor_attributes. ' +
+      WRITE_GATE +
+      ' Exception: the no-op cases (applying an already-present status, or clearing an absent one) report success without attempting a write, so they also return normally while writes are disabled.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -634,7 +677,8 @@ export const tokenMutationTools = [
 export const chatTools = [
   {
     name: 'get_chat_messages',
-    description: 'Get recent chat messages from the game',
+    description:
+      'Get the most recent chat messages from the game log. Use when: you need recent in-game context - what players said, or roll results that already happened.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -656,7 +700,8 @@ export const chatTools = [
 export const userTools = [
   {
     name: 'get_users',
-    description: 'Get the list of users with their online status and roles',
+    description:
+      "List the world's users with their roles and online status. Online status is as of the last world-data load, not a live presence check - no user-activity updates are applied afterwards, so call refresh_world_data first if it matters. Use when: you need to know which user holds the GM role, or who was connected as of that load.",
     inputSchema: {
       type: 'object',
       properties: {},
@@ -670,7 +715,8 @@ export const userTools = [
 export const journalTools = [
   {
     name: 'search_journals',
-    description: 'Search journal entries by name or content',
+    description:
+      'Search journal entries by name and page content. Use when: looking for notes, lore, or handouts by keyword. Do not use when: you already have the journalId - use get_journal.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -689,7 +735,8 @@ export const journalTools = [
   },
   {
     name: 'get_journal',
-    description: 'Get a specific journal entry with its pages',
+    description:
+      'Get one journal entry by id with the text of its pages. Page bodies are HTML-stripped and each is truncated to its first 500 characters, marked with a trailing "...", so long pages come back partial. Use when: you have a journalId and need the text of its pages. Do not use when: you only have a title or keyword - run search_journals first.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -710,7 +757,8 @@ export const journalMutationTools = [
   {
     name: 'create_journal_entry',
     description:
-      'Create a new journal entry with one or more text pages (requires FOUNDRY_WRITE_ENABLED=true + active Socket.IO connection). Defaults to GM-only visibility — pass visibility to let players read it.',
+      'Create a new journal entry with one or more text pages, optionally filed under a folder. Defaults to GM-only visibility - pass visibility to let players read it. Use when: recording session notes, lore, or a handout in the world. Do not use when: adding text to an existing entry - this always creates a new one. ' +
+      WRITE_GATE,
     inputSchema: {
       type: 'object',
       properties: {
@@ -759,7 +807,8 @@ export const journalMutationTools = [
 export const worldTools = [
   {
     name: 'search_world',
-    description: 'Search across all collections (actors, items, scenes, journals) by name',
+    description:
+      'Search across all collections (actors, items, scenes, journals) by name, grouped by collection. Use when: you do not know which collection holds what you are looking for. Do not use when: you already know the collection - use search_actors, search_items, or search_journals. Of those, only search_journals prints document ids; for actor and item ids read the foundry://actors and foundry://items resources, each of which lists up to the first 100 documents (not exhaustive in larger worlds).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -778,7 +827,8 @@ export const worldTools = [
   },
   {
     name: 'get_world_summary',
-    description: 'Get world metadata and collection counts',
+    description:
+      'Get world metadata (title, game system, core version) and per-collection document counts. Use when: orienting yourself in an unfamiliar world, or confirming the game system before system-specific edits.',
     inputSchema: {
       type: 'object',
       properties: {},
@@ -786,7 +836,8 @@ export const worldTools = [
   },
   {
     name: 'refresh_world_data',
-    description: 'Force re-fetch of world data from the FoundryVTT server',
+    description:
+      'Force a re-fetch of the cached world data from the FoundryVTT server. Reads are normally served from a cache that already follows live document changes, so this is rarely needed. Use when: a read still looks stale after an out-of-band change - notably edits to unlinked (synthetic) token actors, which the live update feed does not cover. Refreshes the cache only; it does not modify the world.',
     inputSchema: {
       type: 'object',
       properties: {},

--- a/src/tools/handlers/dice.ts
+++ b/src/tools/handlers/dice.ts
@@ -9,13 +9,14 @@ import type { FoundryClient } from '../../foundry/client.js';
 import { logger } from '../../utils/logger.js';
 // import { McpError, ErrorCode } from '@modelcontextprotocol/sdk/types.js';
 import { BaseTool, type ToolContext, type ToolResult } from '../base.js';
+import { ROLL_DICE_DESCRIPTION } from '../definitions.js';
 
 /**
  * Dice rolling tool implementation
  */
 export class RollDiceTool extends BaseTool {
   readonly name = 'roll_dice';
-  readonly description = 'Roll dice using standard RPG notation (e.g., 1d20, 3d6+4)';
+  readonly description = ROLL_DICE_DESCRIPTION;
   readonly inputSchema = {
     type: 'object',
     properties: {


### PR DESCRIPTION
Closes #182, closes #184, closes #185.

Three of the five open issues were agent-actionable; each is a separate commit.

## #184 — gitignore `.claude/worktrees/`

Two lines in `.gitignore`. `git ls-files .claude/` confirms nothing tracked becomes newly ignored. The stale `manual-w1-clamp/` worktree the issue mentions is not present in this checkout (`git worktree list` shows only the main worktree), so there was nothing to remove.

## #182 — run the docs build on `pull_request`

Adds a `pull_request` trigger with the paths filter the issue specifies, plus `branches: [ main ]` to match `test.yml`/`security.yml`. Deployment stays off PRs.

**This PR is its own proof:** the `build` check ran here and passed, while `deploy` reports `skipped`.

Three things beyond the issue text, all needed to make the change actually work:

- **Per-job permissions.** The top-level block drops to `contents: read`; `deploy` opts into `pages: write` + `id-token: write`. `build` keeps `pages: write` — a job-level block zeroes every unlisted scope, and `actions/configure-pages` calls the Pages REST API on the events where that step still runs. Without it the push build would 403 and deployment would stop.
- **Event-aware concurrency.** The `pages` group was shared; PR runs would otherwise queue behind or cancel a Pages deployment.
- **A PR-only `bun run docs:check` step.** The deploy build runs typedoc with `--skipErrorChecking`, so a PR run reusing it would only catch a deleted or renamed entry point. `docs:check` is the existing script contributors run locally, and it is what makes the new check meaningful. Exits 0 today (0 errors, 3 pre-existing warnings).

The deploy gate is an explicit `push || workflow_dispatch` allow-list rather than `!= 'pull_request'`, so it fails closed if another trigger is added later while preserving manual deploys. `update-docs.yml` and `setup-docs.yml` are untouched.

## #185 — tool-surface audit

Every tool gains a `Use when:` clause, and a `Do not use when:` clause where a genuinely confusable sibling exists. All 11 write-gated tools gain a gate clause naming `FOUNDRY_WRITE_ENABLED` (default `false`) plus the Socket.IO requirement; `delete_actor_item` and `end_combat` gain confirmation wording, and `create_actor_item`/`delete_actor_item` pick up the additive-first / destructive-second guidance ADR-0010 assigns to descriptions.

The gated set was derived from the `assertWriteable()` call sites rather than from naming, then mapped back through the router. It matches the code exactly — no tool claims a gate it does not have, and none is gated silently.

Accuracy was the bar, so a second pass corrected descriptions that promised output the handlers do not produce: `search_items` (rarity filter and price are REST-only), `get_actor_details` and `get_scene_info` (no description text on the Socket.IO path), `get_journal` (pages truncate at 500 chars), `generate_loot` (`treasureType` unused, item list fixed), `get_users` (online status is as-of-last-load), `search_logs` and `get_system_health` (arguments and metrics that never reach the output), `create_actor_item` (compendium source rejected at call time), and `roll_dice` (the fallback parser only accepts modifiers attached to a term). `apply_status_effect` notes that its no-op paths return without attempting a write, keeping its gate clause true. Resource pointers now say they list up to the first 100 documents instead of implying completeness.

Also drops stale `(tracked in #133)` references — that issue is closed, and it never covered `lookup_rule` — and removes the duplicated `roll_dice` description in `dice.ts` in favour of a shared constant, with a test pinning the registry and `getAllTools()` copies together.

**No handler or client behaviour changed.** The only non-description source edits are that shared constant and a `updateActorAttribute` JSDoc correction (it claimed a REST `PUT` and an apiKey requirement; it goes through the Socket.IO write protocol behind the same gate).

## Verification

```
bunx biome check .   exit 0 (11 warnings / 2 infos, all pre-existing, untouched files)
bunx tsc --noEmit    clean
bun run test         26 files, 368 tests passed
bun run docs:check   exit 0
docs.yml             parses
```

Note: `bun test` is not this project's runner — it invokes Bun's own and fails spuriously on a clean tree. `bun run test` (Vitest) is the gate.

## Bugs found and filed, not fixed here

Checking each description against its handler surfaced real behaviour bugs. Fixing them is out of scope for a wording change, so they are filed separately and the descriptions describe the current behaviour accurately in the meantime:

- #214 — `next_turn` indexes combatants in stored order while `combat.turn` indexes the initiative-sorted list; `get_combat_state` also sorts the world cache in place as a read side-effect, making the disagreement order-of-calls dependent
- #215 — `search_logs` array-checks an object response so it always returns 0 results, and drops its `level`/`limit` arguments
- #216 — `get_system_health` / `get_health_status` read top-level fields Zod strips, so every metric prints `N/A`
- #217 — `isConnected()` reports last-known state, so a dropped socket still reads as Connected
- #218 — `activeUsers` is never refreshed after the initial snapshot, so `get_users` online status goes stale
- #219 — `fallbackDiceRoll` silently discards unparsed formula segments and returns a wrong total

## Also not in this PR

- **#183** (`FOUNDRY_*` secrets) needs repo Settings access; the issue itself notes it is owner-only. Commented there that its stated symptom is stale — the workflow now skips rather than failing when the secrets are absent.
- **#189** is Renovate's auto-maintained dashboard.