### PR TITLE
fix: correct the six behaviour bugs found auditing tool descriptions (#214-#219)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Ask your AI assistant things like:
 - `get_scene_info` — current scene details
 - `search_journals` — search notes and handouts
 - `get_journal` — retrieve a specific journal entry
-- `get_users` — list users, roles, and online status as of the last world-data load
+- `get_users` — list users, roles, and live online status
 - `get_combat_state` — combat state and initiative order
 - `get_chat_messages` — recent chat history
 
@@ -177,7 +177,8 @@ needs GM/owner permission. Set `FOUNDRY_WRITE_ENABLED=true` to enable them.
 
 ### Game Mechanics
 
-- `roll_dice` — roll dice; each term must be written `NdS` with any modifier attached directly to it
+- `roll_dice` — roll dice; dice terms (`NdS`) and whole numbers joined by `+`/`-`, with
+  unsupported notation (parentheses, `4d6kh3`) rejected rather than dropped
 - `lookup_rule` — **stub**: returns a templated placeholder, consults no rules source
 
 ### Content Generation
@@ -188,8 +189,9 @@ needs GM/owner permission. Set `FOUNDRY_WRITE_ENABLED=true` to enable them.
 ### Diagnostics (requires REST API module)
 
 - `get_recent_logs` — retrieve filtered FoundryVTT logs
-- `search_logs` — search logs by pattern (matched entries are not returned yet; reports 0 results)
-- `get_system_health` — overall server health status (the resource-metric lines always read "N/A")
+- `search_logs` — search logs by pattern, listing the matching entries
+- `get_system_health` — server health status with versions, user/module counts, memory
+  and log error counts (no CPU or disk metrics)
 - `diagnose_errors` — **stub**: returns a fixed "no errors detected" summary
 - `get_health_status` — comprehensive health diagnostics
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ needs GM/owner permission. Set `FOUNDRY_WRITE_ENABLED=true` to enable them.
   second encounter)
 - `next_turn` — advance the active combat to the next turn (wraps to the next round)
 - `end_combat` — end (delete) the active combat encounter
-- `set_initiative` — set a combatant's initiative in the active combat
+- `set_initiative` — set a combatant's initiative in the active combat, moving the
+  turn marker with the acting combatant if the reorder shifts them
 - `move_token` — move a token to new x/y coordinates on its scene
 - `apply_status_effect` — apply or remove a status condition (e.g. prone, stunned) on a token's actor
 - `update_actor_attributes` — patch an actor's `system` attributes (HP, currency, spell slots, …)
@@ -173,12 +174,15 @@ needs GM/owner permission. Set `FOUNDRY_WRITE_ENABLED=true` to enable them.
 
 - `search_world` — full-text search across all game entities
 - `get_world_summary` — overview of the current world state
-- `refresh_world_data` — reload world data from FoundryVTT
+- `refresh_world_data` — reload world data from FoundryVTT; needed after a dropped
+  connection, whose missed updates are never replayed into the cache
 
 ### Game Mechanics
 
 - `roll_dice` — roll dice; dice terms (`NdS`) and whole numbers joined by `+`/`-`, with
-  unsupported notation (parentheses, `4d6kh3`) rejected rather than dropped
+  unsupported notation (`4d6kh3`, `1d20r1`, `*`) rejected rather than dropped.
+  Parentheses are the one transport difference: FoundryVTT evaluates them when
+  `FOUNDRY_API_KEY` is set, the local roller rejects them otherwise
 - `lookup_rule` — **stub**: returns a templated placeholder, consults no rules source
 
 ### Content Generation
@@ -193,7 +197,8 @@ needs GM/owner permission. Set `FOUNDRY_WRITE_ENABLED=true` to enable them.
 - `get_system_health` — server health status with versions, user/module counts, memory
   and log error counts (no CPU or disk metrics)
 - `diagnose_errors` — **stub**: returns a fixed "no errors detected" summary
-- `get_health_status` — comprehensive health diagnostics
+- `get_health_status` — comprehensive health diagnostics; flags the world snapshot when
+  the cache has stopped following live changes
 
 ## Available Resources
 
@@ -203,7 +208,8 @@ needs GM/owner permission. Set `FOUNDRY_WRITE_ENABLED=true` to enable them.
 - `foundry://scenes/current` — current active scene
 - `foundry://journals` — all journal entries
 - `foundry://users` — online users
-- `foundry://combat` — active combat state
+- `foundry://combat` — active combat state; `combatants` are in initiative order, so
+  `combat.turn` indexes them directly
 - `foundry://world/settings` — world and campaign settings
 - `foundry://system/diagnostics` — system diagnostics (requires REST API module)
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -108,8 +108,8 @@ All features work out of the box with username/password authentication:
 Installing the **Foundry Local REST API** module and setting `FOUNDRY_API_KEY` enables 5 server monitoring tools:
 
 - `get_recent_logs` - Retrieve filtered FoundryVTT logs
-- `search_logs` - Search logs by pattern (matched entries are not returned yet; reports 0 results)
-- `get_system_health` - Overall server health status (the resource-metric lines always read "N/A")
+- `search_logs` - Search logs by pattern, listing the matching entries
+- `get_system_health` - Server health status with versions, user/module counts, memory and log error counts (no CPU or disk metrics)
 - `diagnose_errors` - **stub**: returns a fixed "no errors detected" summary
 - `get_health_status` - Comprehensive health diagnostics
 

--- a/SETUP_GUIDE.md
+++ b/SETUP_GUIDE.md
@@ -83,7 +83,8 @@ All features work out of the box with username/password authentication:
 
 - Search actors, items, scenes, and journals
 - Get detailed actor/item information
-- Dice rolling with FoundryVTT engine
+- Dice rolling (evaluated locally in this mode; FoundryVTT's own `Roll` engine — and
+  with it parenthesised formulas — is used only when `FOUNDRY_API_KEY` is set)
 - Combat state and initiative tracking
 - Chat message history
 - User list and online status
@@ -111,7 +112,8 @@ Installing the **Foundry Local REST API** module and setting `FOUNDRY_API_KEY` e
 - `search_logs` - Search logs by pattern, listing the matching entries
 - `get_system_health` - Server health status with versions, user/module counts, memory and log error counts (no CPU or disk metrics)
 - `diagnose_errors` - **stub**: returns a fixed "no errors detected" summary
-- `get_health_status` - Comprehensive health diagnostics
+- `get_health_status` - Comprehensive health diagnostics; note that in this mode the
+  connection line reports the last REST request's outcome, not a live probe
 
 To enable:
 1. Install the REST API module in FoundryVTT

--- a/src/diagnostics/__tests__/client.test.ts
+++ b/src/diagnostics/__tests__/client.test.ts
@@ -354,6 +354,27 @@ describe('DiagnosticsClient', () => {
 
       expect(result.status).toBe('critical');
     });
+
+    /**
+     * The signature and the JSDoc example both advertised a `score` the body
+     * never sets — the same "documented field that does not exist" family as
+     * #216. Test files are outside the `tsc` surface (`exclude:
+     * **\/*.test.ts`), so the declared shape is pinned here at runtime: the
+     * result carries `status` and nothing else, on both paths.
+     */
+    it.each([
+      { path: 'success', arrange: () => mockFoundryClient.get.mockResolvedValue({ data: {} }) },
+      {
+        path: 'failure',
+        arrange: () => mockFoundryClient.get.mockRejectedValue(new Error('API Error')),
+      },
+    ])('returns status alone on the $path path — no score field', async ({ arrange }) => {
+      arrange();
+
+      const result = await diagnosticsClient.getHealthStatus();
+
+      expect(Object.keys(result)).toEqual(['status']);
+    });
   });
 
   describe('isAvailable', () => {

--- a/src/diagnostics/client.ts
+++ b/src/diagnostics/client.ts
@@ -315,15 +315,21 @@ export class DiagnosticsClient {
   /**
    * Monitor system health and return status summary
    *
-   * @returns Promise resolving to simplified health status
+   * Only the overall status: there is no numeric score behind it. The
+   * signature used to declare an optional `score` and the example used to show
+   * one, but nothing ever set it and {@link SystemHealth} has no such field —
+   * so a caller that read it got `undefined` from a documented field.
+   *
+   * @returns Promise resolving to the overall status, `'critical'` if health
+   *   could not be retrieved at all
    *
    * @example
    * ```typescript
    * const status = await diagnostics.getHealthStatus();
-   * // Returns: { status: 'healthy' | 'warning' | 'critical', score: number }
+   * // Returns: { status: 'healthy' | 'warning' | 'critical' }
    * ```
    */
-  async getHealthStatus(): Promise<{ status: SystemHealth['status']; score?: number }> {
+  async getHealthStatus(): Promise<{ status: SystemHealth['status'] }> {
     try {
       const health = await this.getSystemHealth();
       return {

--- a/src/diagnostics/client.ts
+++ b/src/diagnostics/client.ts
@@ -195,7 +195,6 @@ export class DiagnosticsClient {
    * console.log(`Server status: ${health.status}`);
    * console.log(`Active users: ${health.users.active}/${health.users.total}`);
    * console.log(`Recent errors: ${health.logs.recentErrors}`);
-   * console.log(`Health score: ${health.healthScore}%`);
    *
    * if (health.status === 'critical') {
    *   console.warn('Server requires immediate attention!');

--- a/src/foundry/__tests__/client.test.ts
+++ b/src/foundry/__tests__/client.test.ts
@@ -825,6 +825,35 @@ describe('FoundryClient', () => {
       expect(connected.isWorldDataStale()).toBe(true);
     });
 
+    /**
+     * And the flag has to reach a human. A reconnected client that reports
+     * "✅ Connected" while serving a cache that missed every broadcast from the
+     * outage is the sharper version of #217's second impact bullet.
+     */
+    it('get_health_status marks the cache stale after a drop and a reconnect', async () => {
+      const { handleGetHealthStatus } = await import('../../tools/handlers/diagnostics.js');
+      const { client: connected, socket, fire } = await connectWithMockSocket();
+      const diagnosticsClient = {
+        getSystemHealth: vi.fn().mockRejectedValue(new Error('no REST module')),
+      } as unknown as Parameters<typeof handleGetHealthStatus>[2];
+
+      const before = await handleGetHealthStatus({}, connected, diagnosticsClient);
+      expect((before.content[0] as { text: string }).text).not.toMatch(/stale/i);
+
+      socket.connected = false;
+      fire('disconnect', 'transport close');
+      socket.connected = true;
+      fire('connect');
+
+      const after = (await handleGetHealthStatus({}, connected, diagnosticsClient)).content[0] as {
+        text: string;
+      };
+
+      expect(after.text).toContain('✅ Connected');
+      expect(after.text).toMatch(/stale/i);
+      expect(after.text).toContain('refresh_world_data');
+    });
+
     it('removes the persistent connect listener on explicit disconnect()', async () => {
       const { client: connected, socket, listeners } = await connectWithMockSocket();
 

--- a/src/foundry/__tests__/client.test.ts
+++ b/src/foundry/__tests__/client.test.ts
@@ -157,6 +157,70 @@ describe('FoundryClient', () => {
       await expect(client.searchActors({ query: 'test' })).rejects.toThrow('Persistent error');
       expect(mockAxiosInstance.get).toHaveBeenCalledTimes(2); // Initial + 1 retry
     });
+
+    /**
+     * #217, in the transport that still had it: `_isConnected` latched true at
+     * the connect probe and cleared only inside `disconnect()`, so a server
+     * restart went on reading as "✅ Connected" forever. There is no socket to
+     * ask here, so liveness follows the outcome of the REST requests that do
+     * happen — no extra I/O, and `isConnected()` stays synchronous.
+     */
+    describe('liveness after the connect probe', () => {
+      /** The response interceptor the client registered, as axios would call it. */
+      function interceptor() {
+        const [onFulfilled, onRejected] = mockAxiosInstance.interceptors.response.use.mock
+          .calls[0] as [
+          (response: unknown) => unknown,
+          (error: unknown) => Promise<never>,
+          ...unknown[],
+        ];
+        return { onFulfilled, onRejected };
+      }
+
+      /** An axios rejection with no HTTP response — the server never answered. */
+      function transportFailure() {
+        return Object.assign(new Error('connect ECONNREFUSED'), { isAxiosError: true });
+      }
+
+      /** An axios rejection carrying a reply — the server answered, badly. */
+      function httpError(status: number) {
+        return Object.assign(new Error(`HTTP ${status}`), {
+          isAxiosError: true,
+          response: { status },
+        });
+      }
+
+      beforeEach(async () => {
+        mockAxiosInstance.get.mockResolvedValue({ status: 200, data: {} });
+        await client.connect();
+        expect(client.isConnected()).toBe(true);
+      });
+
+      it('reports disconnected once a request finds the server gone', async () => {
+        const { onRejected } = interceptor();
+
+        await expect(onRejected(transportFailure())).rejects.toThrow('ECONNREFUSED');
+
+        expect(client.isConnected()).toBe(false);
+      });
+
+      it('reports connected again once a request succeeds', async () => {
+        const { onFulfilled, onRejected } = interceptor();
+        await expect(onRejected(transportFailure())).rejects.toThrow('ECONNREFUSED');
+
+        onFulfilled({ status: 200, data: {} });
+
+        expect(client.isConnected()).toBe(true);
+      });
+
+      it('treats an error status as reachable — the server answered', async () => {
+        const { onRejected } = interceptor();
+
+        await expect(onRejected(httpError(500))).rejects.toThrow('HTTP 500');
+
+        expect(client.isConnected()).toBe(true);
+      });
+    });
   });
 
   /**
@@ -870,7 +934,12 @@ describe('FoundryClient', () => {
       expect(listeners.get('userActivity') ?? []).toHaveLength(0);
     });
 
-    it('keeps REST API mode connected — it has no socket at all', async () => {
+    /**
+     * REST mode has no socket to consult, so the socket clause must not apply
+     * to it. Its own liveness signal — the last observed request outcome — is
+     * covered in "liveness after the connect probe" above.
+     */
+    it('does not require a socket in REST API mode', async () => {
       const restClient = new FoundryClient({
         baseUrl: 'http://localhost:30000',
         apiKey: 'test-api-key',

--- a/src/foundry/__tests__/client.test.ts
+++ b/src/foundry/__tests__/client.test.ts
@@ -537,12 +537,32 @@ describe('FoundryClient', () => {
         expect(result.total).toBe(21);
       });
 
-      it('still refuses notation outside the dice alphabet on the REST path', async () => {
+      /**
+       * REST accepts a wider grammar, but when it does refuse the message has
+       * to be as specific as the local path's: `roll_dice` promises `4d6kh3`
+       * and `1d20r1` are "rejected with an error naming the problem", and that
+       * promise is not scoped to a transport. A bare `Invalid dice formula:
+       * 4d6kh3` names nothing.
+       */
+      it('names the offending character when REST refuses notation outside the dice alphabet', async () => {
         const rest = restClient();
-        await expect(rest.rollDice('4d6kh3')).rejects.toThrow(/Invalid dice formula/);
-        await expect(rest.rollDice('1d20*2')).rejects.toThrow(/Invalid dice formula/);
-        await expect(rest.rollDice('')).rejects.toThrow(/Invalid dice formula/);
+        await expect(rest.rollDice('4d6kh3')).rejects.toThrow(/unexpected "k" at position 3/);
+        await expect(rest.rollDice('1d20r1')).rejects.toThrow(/unexpected "r" at position 4/);
+        await expect(rest.rollDice('1d20*2')).rejects.toThrow(/unexpected "\*" at position 4/);
+        await expect(rest.rollDice('1d20+STR')).rejects.toThrow(/unexpected "S" at position 5/);
+        await expect(rest.rollDice('')).rejects.toThrow(/the formula is empty/);
         await expect(rest.rollDice('1d20'.repeat(30))).rejects.toThrow(/Invalid dice formula/);
+        expect(mockAxiosInstance.post).not.toHaveBeenCalled();
+      });
+
+      it('does not blame parentheses, which REST supports, for an unrelated bad character', async () => {
+        // Delegating to the local parser here would report the parentheses —
+        // the wrong problem, since FoundryVTT evaluates those fine.
+        const rest = restClient();
+        await expect(rest.rollDice('(1d20+5)*2')).rejects.toThrow(/unexpected "\*" at position 8/);
+        await expect(rest.rollDice('(1d20+5)*2')).rejects.not.toThrow(
+          /parentheses are not supported/i,
+        );
         expect(mockAxiosInstance.post).not.toHaveBeenCalled();
       });
 

--- a/src/foundry/__tests__/client.test.ts
+++ b/src/foundry/__tests__/client.test.ts
@@ -474,4 +474,189 @@ describe('FoundryClient', () => {
       expect(listeners.has('world')).toBe(false);
     });
   });
+
+  /**
+   * Issue #217 — liveness must come from the socket, not a latched flag.
+   *
+   * `_isConnected` used to be cleared only by an explicit `disconnect()`, so a
+   * socket that dropped on its own (server restart, network loss) still read as
+   * connected and `get_health_status` still printed "✅ Connected".
+   */
+  describe('socket liveness (#217)', () => {
+    /** Mock socket that records listeners and lets the test fire them. */
+    function buildHandshakeSocket(worldData: Record<string, unknown>) {
+      const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
+      const socket = {
+        connected: true,
+        on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+          const existing = listeners.get(event) ?? [];
+          existing.push(handler);
+          listeners.set(event, existing);
+          return socket;
+        }),
+        once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+          const existing = listeners.get(event) ?? [];
+          existing.push(handler);
+          listeners.set(event, existing);
+          return socket;
+        }),
+        off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+          const remaining = (listeners.get(event) ?? []).filter((h) => h !== handler);
+          listeners.set(event, remaining);
+          return socket;
+        }),
+        emit: vi.fn((event: string, ack?: (payload: unknown) => void) => {
+          if (event === 'world' && typeof ack === 'function') {
+            ack(worldData);
+          }
+          return socket;
+        }),
+        disconnect: vi.fn(() => {
+          socket.connected = false;
+          return socket;
+        }),
+      };
+      const fire = (event: string, ...args: unknown[]) => {
+        for (const handler of [...(listeners.get(event) ?? [])]) {
+          handler(...args);
+        }
+      };
+      return { socket, listeners, fire };
+    }
+
+    const WORLD_DATA = {
+      userId: 'test-user-id',
+      world: { id: 'w', title: 'Test World' },
+      system: { id: 'dnd5e', version: '3.3.1' },
+      release: { version: '12.331' },
+      actors: [],
+      scenes: [],
+      items: [],
+      journal: [],
+      messages: [],
+      combats: [],
+      users: [
+        { _id: 'user-aaaaaaaaaaaaaa', name: 'GM', role: 4 },
+        { _id: 'user-bbbbbbbbbbbbbb', name: 'Player', role: 1 },
+      ],
+      activeUsers: ['user-aaaaaaaaaaaaaa'],
+      settings: [],
+      macros: [],
+      playlists: [],
+      tables: [],
+      folders: [],
+    };
+
+    async function connectWithMockSocket() {
+      const { io } = await import('socket.io-client');
+      const { authenticateFoundry } = await import('../auth.js');
+      // afterEach's resetAllMocks() clears the module-factory resolved value.
+      vi.mocked(authenticateFoundry).mockResolvedValue({
+        session: 'test-session',
+        userId: 'test-user-id',
+      });
+      const harness = buildHandshakeSocket(structuredClone(WORLD_DATA));
+      vi.mocked(io).mockReturnValue(harness.socket as never);
+
+      const connected = new FoundryClient({
+        baseUrl: 'http://localhost:30000',
+        username: 'gm',
+        password: 'secret',
+      });
+
+      const connecting = connected.connect();
+      // connect() awaits authentication before attaching the handshake
+      // listeners, so wait for the 'session' listener before firing it.
+      await vi.waitFor(() => expect(harness.listeners.get('session')?.length).toBe(1));
+      harness.fire('session', { userId: 'test-user-id' });
+      await connecting;
+
+      return { client: connected, ...harness };
+    }
+
+    it('reports connected after a successful handshake', async () => {
+      const { client: connected } = await connectWithMockSocket();
+      expect(connected.isConnected()).toBe(true);
+    });
+
+    it('reports disconnected once the socket drops without disconnect()', async () => {
+      const { client: connected, socket, fire } = await connectWithMockSocket();
+
+      // Simulate the server going away: Socket.IO flips `connected` and emits
+      // 'disconnect'. `disconnect()` is deliberately NOT called.
+      socket.connected = false;
+      fire('disconnect', 'transport close');
+
+      expect(connected.isConnected()).toBe(false);
+    });
+
+    it('reports disconnected on a silent drop even without a disconnect event', async () => {
+      const { client: connected, socket } = await connectWithMockSocket();
+      socket.connected = false;
+      expect(connected.isConnected()).toBe(false);
+    });
+
+    it('get_health_status reports the dropped socket', async () => {
+      const { handleGetHealthStatus } = await import('../../tools/handlers/diagnostics.js');
+      const { client: connected, socket, fire } = await connectWithMockSocket();
+      const diagnosticsClient = {
+        getSystemHealth: vi.fn().mockRejectedValue(new Error('no REST module')),
+      };
+
+      const before = await handleGetHealthStatus(
+        {},
+        connected,
+        diagnosticsClient as unknown as Parameters<typeof handleGetHealthStatus>[2],
+      );
+      expect((before.content[0] as { text: string }).text).toContain('✅ Connected');
+
+      socket.connected = false;
+      fire('disconnect', 'transport close');
+
+      const after = await handleGetHealthStatus(
+        {},
+        connected,
+        diagnosticsClient as unknown as Parameters<typeof handleGetHealthStatus>[2],
+      );
+      expect((after.content[0] as { text: string }).text).toContain('❌ Disconnected');
+    });
+
+    it('marks the cached world data stale after a drop, but keeps serving it', async () => {
+      const { client: connected, socket, fire } = await connectWithMockSocket();
+      expect(connected.isWorldDataStale()).toBe(false);
+
+      socket.connected = false;
+      fire('disconnect', 'transport close');
+
+      expect(connected.isWorldDataStale()).toBe(true);
+      // The snapshot is retained — a stale answer beats no answer.
+      expect(connected.hasWorldData()).toBe(true);
+      expect(connected.getUsers().users).toHaveLength(2);
+    });
+
+    it('removes the persistent disconnect listener on explicit disconnect()', async () => {
+      const { client: connected, socket, listeners } = await connectWithMockSocket();
+
+      const registered = socket.on.mock.calls
+        .filter(([event]) => event === 'disconnect')
+        .map(([, handler]) => handler);
+      expect(registered).toHaveLength(1);
+
+      await connected.disconnect();
+
+      expect(socket.off).toHaveBeenCalledWith('disconnect', registered[0]);
+      expect(listeners.get('disconnect') ?? []).toHaveLength(0);
+    });
+
+    it('keeps REST API mode connected — it has no socket at all', async () => {
+      const restClient = new FoundryClient({
+        baseUrl: 'http://localhost:30000',
+        apiKey: 'test-api-key',
+      });
+      mockAxiosInstance.get.mockResolvedValue({ status: 200, data: {} });
+
+      await restClient.connect();
+      expect(restClient.isConnected()).toBe(true);
+    });
+  });
 });

--- a/src/foundry/__tests__/client.test.ts
+++ b/src/foundry/__tests__/client.test.ts
@@ -538,6 +538,27 @@ describe('FoundryClient', () => {
       });
 
       /**
+       * The REST body is external input. A 200 that carries no numeric `total`
+       * must not become a `DiceRoll` whose `total` is `undefined` while the
+       * type promises `number` — `roll_dice` would render that to the caller.
+       * A malformed body is treated like any other REST failure: fall through
+       * to the local roller, which produces a real total.
+       */
+      it('falls back to the local roller when the REST body has no numeric total', async () => {
+        mockAxiosInstance.post.mockResolvedValue({
+          data: { error: 'something went sideways' },
+        });
+
+        const result = await restClient().rollDice('1d20+5');
+
+        expect(mockAxiosInstance.post).toHaveBeenCalled();
+        expect(typeof result.total).toBe('number');
+        expect(Number.isNaN(result.total)).toBe(false);
+        expect(result.total).toBeGreaterThanOrEqual(6);
+        expect(result.total).toBeLessThanOrEqual(25);
+      });
+
+      /**
        * REST accepts a wider grammar, but when it does refuse the message has
        * to be as specific as the local path's: `roll_dice` promises `4d6kh3`
        * and `1d20r1` are "rejected with an error naming the problem", and that

--- a/src/foundry/__tests__/client.test.ts
+++ b/src/foundry/__tests__/client.test.ts
@@ -423,16 +423,73 @@ describe('FoundryClient', () => {
         expect(result.breakdown.endsWith(` = ${result.total}`)).toBe(true);
       });
 
+      /**
+       * The message has to name the problem, not just the formula: `roll_dice`
+       * advertises `4d6kh3` and `1d20r1` by name as notation that "is rejected
+       * with an error naming the problem". A generic `Invalid dice formula:
+       * 4d6kh3` does not tell the caller which character was not understood.
+       */
       it.each([
         { formula: '(1d20+5)', match: /parenthes/i },
-        { formula: '(1d20+5)*2', match: /Invalid dice formula/ },
-        { formula: '4d6kh3', match: /Invalid dice formula/ },
-        { formula: '1d20+STR', match: /Invalid dice formula/ },
+        { formula: '(1d20+5)*2', match: /parenthes/i },
+        { formula: '4d6kh3', match: /unexpected "k" at position 3/ },
+        { formula: '1d20r1', match: /unexpected "r" at position 4/ },
+        { formula: '1d20*2', match: /unexpected "\*" at position 4/ },
+        { formula: '1d20+STR', match: /unexpected "S" at position 5/ },
         { formula: '1d20+', match: /ends with/i },
         { formula: '1d20 5', match: /unexpected/i },
         { formula: '1d0', match: /at least 1 side/i },
       ])('rejects $formula instead of dropping part of it', async ({ formula, match }) => {
         await expect(client.rollDice(formula)).rejects.toThrow(match);
+      });
+    });
+
+    /**
+     * The transports do not accept the same grammar, and that is deliberate.
+     * REST hands the formula to FoundryVTT's own `Roll` engine, which
+     * understands more than the local fallback parser does; capping REST at
+     * the fallback's grammar would drop a capability #219 never asked to lose.
+     * Both transports still refuse anything outside the dice alphabet.
+     */
+    describe('per-transport formula grammar', () => {
+      function restClient() {
+        return new FoundryClient({
+          baseUrl: 'http://localhost:30000',
+          apiKey: 'test-api-key',
+        });
+      }
+
+      it('lets a parenthesised formula through to FoundryVTT over REST', async () => {
+        mockAxiosInstance.post.mockResolvedValue({
+          data: { total: 21, terms: [{ results: [16] }] },
+        });
+
+        const result = await restClient().rollDice('(1d20+5)', 'Attack');
+
+        expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/dice/roll', {
+          formula: '(1d20+5)',
+          flavor: 'Attack',
+        });
+        expect(result.total).toBe(21);
+      });
+
+      it('still refuses notation outside the dice alphabet on the REST path', async () => {
+        const rest = restClient();
+        await expect(rest.rollDice('4d6kh3')).rejects.toThrow(/Invalid dice formula/);
+        await expect(rest.rollDice('1d20*2')).rejects.toThrow(/Invalid dice formula/);
+        await expect(rest.rollDice('')).rejects.toThrow(/Invalid dice formula/);
+        await expect(rest.rollDice('1d20'.repeat(30))).rejects.toThrow(/Invalid dice formula/);
+        expect(mockAxiosInstance.post).not.toHaveBeenCalled();
+      });
+
+      it('rejects a parenthesised formula on the local path — nothing there can roll it', async () => {
+        await expect(client.rollDice('(1d20+5)')).rejects.toThrow(/parenthes/i);
+      });
+
+      it('reports the parse error when REST is unreachable and the fallback cannot roll it', async () => {
+        mockAxiosInstance.post.mockRejectedValue(new Error('ECONNREFUSED'));
+
+        await expect(restClient().rollDice('(1d20+5)')).rejects.toThrow(/parenthes/i);
       });
     });
   });

--- a/src/foundry/__tests__/client.test.ts
+++ b/src/foundry/__tests__/client.test.ts
@@ -591,7 +591,7 @@ describe('FoundryClient', () => {
       folders: [],
     };
 
-    async function connectWithMockSocket() {
+    async function connectWithMockSocket(existing?: FoundryClient) {
       const { io } = await import('socket.io-client');
       const { authenticateFoundry } = await import('../auth.js');
       // afterEach's resetAllMocks() clears the module-factory resolved value.
@@ -602,11 +602,13 @@ describe('FoundryClient', () => {
       const harness = buildHandshakeSocket(structuredClone(WORLD_DATA));
       vi.mocked(io).mockReturnValue(harness.socket as never);
 
-      const connected = new FoundryClient({
-        baseUrl: 'http://localhost:30000',
-        username: 'gm',
-        password: 'secret',
-      });
+      const connected =
+        existing ??
+        new FoundryClient({
+          baseUrl: 'http://localhost:30000',
+          username: 'gm',
+          password: 'secret',
+        });
 
       const connecting = connected.connect();
       // connect() awaits authentication before attaching the handshake
@@ -676,6 +678,64 @@ describe('FoundryClient', () => {
       // The snapshot is retained — a stale answer beats no answer.
       expect(connected.hasWorldData()).toBe(true);
       expect(connected.getUsers().users).toHaveLength(2);
+    });
+
+    /**
+     * socket.io-client reconnects with `reconnection: true` by default and
+     * `sessionSocketOptions` does not turn it off, so after a transient drop
+     * the manager brings the SAME socket back up and re-emits 'connect'.
+     * Liveness has to follow it back up, not latch off for the rest of the
+     * process while broadcasts and writes are working again.
+     */
+    it('reports connected again when the socket auto-reconnects', async () => {
+      const { client: connected, socket, fire } = await connectWithMockSocket();
+
+      socket.connected = false;
+      fire('disconnect', 'transport close');
+      expect(connected.isConnected()).toBe(false);
+
+      // What socket.io does on an automatic reconnect of the same instance.
+      socket.connected = true;
+      fire('connect');
+
+      expect(connected.isConnected()).toBe(true);
+      // The gap was not replayed: broadcasts missed while the socket was down
+      // are gone, so the cache stays flagged until an explicit refresh.
+      expect(connected.isWorldDataStale()).toBe(true);
+    });
+
+    it('removes the persistent connect listener on explicit disconnect()', async () => {
+      const { client: connected, socket, listeners } = await connectWithMockSocket();
+
+      const registered = socket.on.mock.calls
+        .filter(([event]) => event === 'connect')
+        .map(([, handler]) => handler);
+      expect(registered).toHaveLength(1);
+
+      await connected.disconnect();
+
+      expect(socket.off).toHaveBeenCalledWith('connect', registered[0]);
+      expect(listeners.get('connect') ?? []).toHaveLength(0);
+    });
+
+    /**
+     * `DiagnosticsClient.testAuthentication()` calls `connect()` on a client
+     * that is already connected. The superseded socket used to keep the same
+     * bound 'disconnect' handler, so when it closed it cleared liveness for the
+     * live socket that had replaced it.
+     */
+    it('a superseded socket cannot clear liveness for its replacement', async () => {
+      const first = await connectWithMockSocket();
+      const second = await connectWithMockSocket(first.client);
+      expect(second.socket).not.toBe(first.socket);
+      expect(first.client.isConnected()).toBe(true);
+
+      // The orphaned socket finally closes.
+      first.socket.connected = false;
+      first.fire('disconnect', 'transport close');
+
+      expect(first.client.isConnected()).toBe(true);
+      expect(first.client.isWorldDataStale()).toBe(false);
     });
 
     it('removes the persistent disconnect listener on explicit disconnect()', async () => {

--- a/src/foundry/__tests__/client.test.ts
+++ b/src/foundry/__tests__/client.test.ts
@@ -482,7 +482,7 @@ describe('FoundryClient', () => {
    * socket that dropped on its own (server restart, network loss) still read as
    * connected and `get_health_status` still printed "✅ Connected".
    */
-  describe('socket liveness (#217)', () => {
+  describe('socket liveness (#217) and live presence (#218)', () => {
     /** Mock socket that records listeners and lets the test fire them. */
     function buildHandshakeSocket(worldData: Record<string, unknown>) {
       const listeners = new Map<string, Array<(...args: unknown[]) => void>>();
@@ -646,6 +646,67 @@ describe('FoundryClient', () => {
 
       expect(socket.off).toHaveBeenCalledWith('disconnect', registered[0]);
       expect(listeners.get('disconnect') ?? []).toHaveLength(0);
+    });
+
+    /**
+     * Issue #218 — presence used to be frozen at the world snapshot: nothing
+     * subscribed to `userActivity`, and `modifyDocument` maps onto document
+     * collections, never the top-level `activeUsers` field.
+     */
+    it('applies a userActivity login to the cache and to get_users', async () => {
+      const { handleGetUsers } = await import('../../tools/handlers/users.js');
+      const { client: connected, fire } = await connectWithMockSocket();
+
+      expect(connected.getUsers().activeUsers).toEqual(['user-aaaaaaaaaaaaaa']);
+      const before = await handleGetUsers({}, connected);
+      expect((before.content[0] as { text: string }).text).toContain('(1/2 online)');
+
+      fire('userActivity', 'user-bbbbbbbbbbbbbb', { active: true });
+
+      expect(connected.getUsers().activeUsers).toEqual([
+        'user-aaaaaaaaaaaaaa',
+        'user-bbbbbbbbbbbbbb',
+      ]);
+      const after = await handleGetUsers({}, connected);
+      const text = (after.content[0] as { text: string }).text;
+      expect(text).toContain('(2/2 online)');
+      expect(text).toContain('**Player** (Player) — Online');
+    });
+
+    it('applies a userActivity logout to the cache and to get_users', async () => {
+      const { handleGetUsers } = await import('../../tools/handlers/users.js');
+      const { client: connected, fire } = await connectWithMockSocket();
+
+      fire('userActivity', 'user-aaaaaaaaaaaaaa', { active: false });
+
+      expect(connected.getUsers().activeUsers).toEqual([]);
+      const after = await handleGetUsers({}, connected);
+      const text = (after.content[0] as { text: string }).text;
+      expect(text).toContain('(0/2 online)');
+      expect(text).toContain('**GM** (Game Master) — Offline');
+    });
+
+    it('ignores a malformed userActivity payload rather than corrupting the cache', async () => {
+      const { client: connected, fire } = await connectWithMockSocket();
+
+      fire('userActivity', 42, { active: false });
+      fire('userActivity', 'user-bbbbbbbbbbbbbb', { active: 'yes' });
+
+      expect(connected.getUsers().activeUsers).toEqual(['user-aaaaaaaaaaaaaa']);
+    });
+
+    it('removes the userActivity listener on disconnect()', async () => {
+      const { client: connected, socket, listeners } = await connectWithMockSocket();
+
+      const registered = socket.on.mock.calls
+        .filter(([event]) => event === 'userActivity')
+        .map(([, handler]) => handler);
+      expect(registered).toHaveLength(1);
+
+      await connected.disconnect();
+
+      expect(socket.off).toHaveBeenCalledWith('userActivity', registered[0]);
+      expect(listeners.get('userActivity') ?? []).toHaveLength(0);
     });
 
     it('keeps REST API mode connected — it has no socket at all', async () => {

--- a/src/foundry/__tests__/client.test.ts
+++ b/src/foundry/__tests__/client.test.ts
@@ -391,6 +391,50 @@ describe('FoundryClient', () => {
       expect(result.total).toBeGreaterThanOrEqual(3);
       expect(result.total).toBeLessThanOrEqual(18);
     });
+
+    /**
+     * Issue #219 — the old parser only captured a modifier glued directly to a
+     * dice term, so every formula below returned a plausible-but-wrong total
+     * with the unparsed part silently dropped. RNG is pinned so the totals are
+     * exact rather than ranges.
+     */
+    describe('formulas that used to be silently mis-totalled (#219)', () => {
+      beforeEach(() => {
+        // Math.floor(0.5 * sides) + 1 — the middle-ish face of every die.
+        vi.spyOn(Math, 'random').mockReturnValue(0.5);
+      });
+
+      afterEach(() => {
+        vi.restoreAllMocks();
+      });
+
+      it.each([
+        { formula: '1d20+5', total: 16, breakdown: '1d20: [11] + 5 = 16' },
+        { formula: '1d20 + 5', total: 16, breakdown: '1d20: [11] + 5 = 16' },
+        { formula: '1d20+5+3', total: 19, breakdown: '1d20: [11] + 5 + 3 = 19' },
+        { formula: 'd20', total: 11, breakdown: '1d20: [11] = 11' },
+        { formula: '2d6+1d4', total: 11, breakdown: '2d6: [4, 4] + 1d4: [3] = 11' },
+        { formula: '2d6 - 1', total: 7, breakdown: '2d6: [4, 4] - 1 = 7' },
+      ])('rolls $formula for exactly $total', async ({ formula, total, breakdown }) => {
+        const result = await client.rollDice(formula);
+        expect(result.total).toBe(total);
+        expect(result.breakdown).toBe(breakdown);
+        // The rendered breakdown must agree with the total it claims.
+        expect(result.breakdown.endsWith(` = ${result.total}`)).toBe(true);
+      });
+
+      it.each([
+        { formula: '(1d20+5)', match: /parenthes/i },
+        { formula: '(1d20+5)*2', match: /Invalid dice formula/ },
+        { formula: '4d6kh3', match: /Invalid dice formula/ },
+        { formula: '1d20+STR', match: /Invalid dice formula/ },
+        { formula: '1d20+', match: /ends with/i },
+        { formula: '1d20 5', match: /unexpected/i },
+        { formula: '1d0', match: /at least 1 side/i },
+      ])('rejects $formula instead of dropping part of it', async ({ formula, match }) => {
+        await expect(client.rollDice(formula)).rejects.toThrow(match);
+      });
+    });
   });
 
   describe('disconnect', () => {

--- a/src/foundry/__tests__/dice-formula.test.ts
+++ b/src/foundry/__tests__/dice-formula.test.ts
@@ -1,0 +1,148 @@
+/**
+ * @fileoverview Unit tests for the dice formula parser/evaluator (#219).
+ *
+ * The old `fallbackDiceRoll` regex only captured a modifier glued directly to a
+ * dice term, so anything else the character-class validator let through was
+ * silently dropped from the total. These tests pin the two properties that
+ * replaced it: correct evaluation of the formulas we support, and a loud,
+ * specific error for everything else.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { evaluateDiceFormula, parseDiceFormula } from '../dice-formula.js';
+
+/** Deterministic RNG: replays a fixed sequence, then repeats the last value. */
+function seededRng(values: number[]): () => number {
+  let index = 0;
+  return () => values[Math.min(index++, values.length - 1)] ?? 0;
+}
+
+describe('parseDiceFormula', () => {
+  it('parses a bare dice term', () => {
+    expect(parseDiceFormula('3d6')).toEqual([{ kind: 'dice', sign: 1, count: 3, sides: 6 }]);
+  });
+
+  it('defaults a count-less term to a single die', () => {
+    expect(parseDiceFormula('d20')).toEqual([{ kind: 'dice', sign: 1, count: 1, sides: 20 }]);
+  });
+
+  it('parses dice and constants in any mix', () => {
+    expect(parseDiceFormula('2d6 + 1d4 - 3')).toEqual([
+      { kind: 'dice', sign: 1, count: 2, sides: 6 },
+      { kind: 'dice', sign: 1, count: 1, sides: 4 },
+      { kind: 'constant', sign: -1, value: 3 },
+    ]);
+  });
+
+  it('accepts a leading sign', () => {
+    expect(parseDiceFormula('-1d4+2')).toEqual([
+      { kind: 'dice', sign: -1, count: 1, sides: 4 },
+      { kind: 'constant', sign: 1, value: 2 },
+    ]);
+  });
+});
+
+/**
+ * The exact table from issue #219: every one of these used to return a
+ * plausible-but-wrong number.
+ */
+describe.each([
+  {
+    formula: '1d20+5',
+    rng: [0.5],
+    total: 16,
+    breakdown: '1d20: [11] + 5 = 16',
+  },
+  {
+    formula: '1d20 + 5',
+    rng: [0.5],
+    total: 16,
+    breakdown: '1d20: [11] + 5 = 16',
+  },
+  {
+    formula: '1d20+5+3',
+    rng: [0.5],
+    total: 19,
+    breakdown: '1d20: [11] + 5 + 3 = 19',
+  },
+  {
+    formula: 'd20',
+    rng: [0.5],
+    total: 11,
+    breakdown: '1d20: [11] = 11',
+  },
+  {
+    formula: '2d6+1d4',
+    rng: [0, 0.99, 0.5],
+    total: 10,
+    breakdown: '2d6: [1, 6] + 1d4: [3] = 10',
+  },
+  {
+    formula: '1d20 - 2',
+    rng: [0.95],
+    total: 18,
+    breakdown: '1d20: [20] - 2 = 18',
+  },
+  {
+    formula: '10 - 4',
+    rng: [],
+    total: 6,
+    breakdown: '10 - 4 = 6',
+  },
+  {
+    formula: '0d6+2',
+    rng: [],
+    total: 2,
+    breakdown: '0d6: [] + 2 = 2',
+  },
+])('evaluateDiceFormula($formula)', ({ formula, rng, total, breakdown }) => {
+  it(`totals ${total}`, () => {
+    expect(evaluateDiceFormula(formula, seededRng(rng)).total).toBe(total);
+  });
+
+  it('renders a breakdown matching the total', () => {
+    const result = evaluateDiceFormula(formula, seededRng(rng));
+    expect(result.breakdown).toBe(breakdown);
+  });
+
+  it('reports per-term rolls that sum to the total', () => {
+    const result = evaluateDiceFormula(formula, seededRng(rng));
+    const summed = result.terms.reduce((sum, term) => sum + term.sign * term.value, 0);
+    expect(summed).toBe(result.total);
+
+    for (const term of result.terms) {
+      if (term.kind !== 'dice') {
+        continue;
+      }
+      expect(term.rolls).toHaveLength(term.count);
+      expect(term.rolls.reduce((sum, roll) => sum + roll, 0)).toBe(term.value);
+      for (const roll of term.rolls) {
+        expect(roll).toBeGreaterThanOrEqual(1);
+        expect(roll).toBeLessThanOrEqual(term.sides);
+      }
+    }
+  });
+});
+
+describe.each([
+  { formula: '(1d20+5)', reason: 'parentheses', match: /parenthes/i },
+  { formula: '(1d20+5)*2', reason: 'parentheses', match: /parenthes/i },
+  { formula: '1d20+', reason: 'a dangling operator', match: /ends with/i },
+  { formula: '+', reason: 'a lone operator', match: /ends with/i },
+  { formula: '1d20 5', reason: 'a missing operator', match: /unexpected/i },
+  { formula: 'd', reason: 'a die with no sides', match: /unexpected/i },
+  { formula: '1d0', reason: 'a zero-sided die', match: /at least 1 side/i },
+  { formula: '', reason: 'an empty formula', match: /empty/i },
+  { formula: '   ', reason: 'a whitespace-only formula', match: /empty/i },
+  { formula: '4d6kh3', reason: 'unsupported Foundry syntax', match: /unexpected/i },
+  { formula: '2000d6', reason: 'an absurd dice count', match: /too many dice/i },
+])('rejects $reason', ({ formula, match }) => {
+  it(`throws for "${formula}" rather than dropping part of it`, () => {
+    expect(() => parseDiceFormula(formula)).toThrow(match);
+    expect(() => evaluateDiceFormula(formula)).toThrow(match);
+  });
+
+  it(`names the offending formula for "${formula}"`, () => {
+    expect(() => parseDiceFormula(formula)).toThrow(/dice formula/i);
+  });
+});

--- a/src/foundry/__tests__/world-cache.test.ts
+++ b/src/foundry/__tests__/world-cache.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it } from 'vitest';
 import type { WorldData } from '../types.js';
 import {
   applyDocumentBroadcast,
+  applyUserActivity,
   type DocumentBroadcast,
   parseDocumentBroadcast,
+  parseUserActivity,
 } from '../world-cache.js';
 
 const ACTOR_ID = 'aaaaaaaaaaaaaaaa';
@@ -291,5 +293,82 @@ describe('applyDocumentBroadcast — embedded documents', () => {
         parentUuid: `Scene.${SCENE_ID}.Token.${TOKEN_ID}.Actor.${ACTOR_ID}`,
       }),
     ).toBe(false);
+  });
+});
+
+/**
+ * Issue #218 — `activeUsers` is a top-level `WorldData` field, not a document
+ * collection, so `modifyDocument` never touches it. FoundryVTT signals presence
+ * on the separate `userActivity` event instead.
+ */
+describe('parseUserActivity', () => {
+  const USER_ID = 'user0000user0001';
+
+  it('parses a logout broadcast', () => {
+    expect(parseUserActivity(USER_ID, { active: false })).toEqual({
+      userId: USER_ID,
+      active: false,
+    });
+  });
+
+  it('parses a login broadcast', () => {
+    expect(parseUserActivity(USER_ID, { active: true })).toEqual({
+      userId: USER_ID,
+      active: true,
+    });
+  });
+
+  it('treats an activity ping with no `active` flag as present, like Foundry does', () => {
+    expect(parseUserActivity(USER_ID, { cursor: { x: 10, y: 20 } })).toEqual({
+      userId: USER_ID,
+      active: true,
+    });
+    expect(parseUserActivity(USER_ID, undefined)).toEqual({ userId: USER_ID, active: true });
+  });
+
+  it.each([
+    ['a non-string user id', 42, { active: true }],
+    ['an empty user id', '', { active: true }],
+    ['a non-object activity payload', 'user0000user0001', 'nope'],
+    ['a non-boolean active flag', 'user0000user0001', { active: 'yes' }],
+  ])('rejects %s', (_label, userId, activityData) => {
+    expect(parseUserActivity(userId, activityData)).toBeNull();
+  });
+});
+
+describe('applyUserActivity', () => {
+  const USER_ID = 'user0000user0001';
+  const OTHER_ID = 'user0000user0002';
+
+  it('adds a user that just logged in', () => {
+    const worldData = buildWorldData();
+    worldData.activeUsers = [OTHER_ID];
+
+    expect(applyUserActivity(worldData, { userId: USER_ID, active: true })).toBe(true);
+    expect(worldData.activeUsers).toEqual([OTHER_ID, USER_ID]);
+  });
+
+  it('removes a user that just logged out', () => {
+    const worldData = buildWorldData();
+    worldData.activeUsers = [OTHER_ID, USER_ID];
+
+    expect(applyUserActivity(worldData, { userId: USER_ID, active: false })).toBe(true);
+    expect(worldData.activeUsers).toEqual([OTHER_ID]);
+  });
+
+  it('is idempotent — an activity ping from an already-active user changes nothing', () => {
+    const worldData = buildWorldData();
+    worldData.activeUsers = [USER_ID];
+
+    expect(applyUserActivity(worldData, { userId: USER_ID, active: true })).toBe(false);
+    expect(worldData.activeUsers).toEqual([USER_ID]);
+  });
+
+  it('is idempotent for a logout of a user that is already absent', () => {
+    const worldData = buildWorldData();
+    worldData.activeUsers = [OTHER_ID];
+
+    expect(applyUserActivity(worldData, { userId: USER_ID, active: false })).toBe(false);
+    expect(worldData.activeUsers).toEqual([OTHER_ID]);
   });
 });

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -233,6 +233,9 @@ export class FoundryClient {
    * Connects Socket.IO with an authenticated session and loads worldData.
    */
   private connectAndLoadWorld(session: string): Promise<WorldData> {
+    // A previous socket must not outlive its replacement (see `detachSocket`).
+    this.detachSocket();
+
     return new Promise((resolve, reject) => {
       this.socket = io(this.config.baseUrl, sessionSocketOptions(session));
 
@@ -271,7 +274,9 @@ export class FoundryClient {
           // only moves on this event.
           this.socket?.on('userActivity', this.onUserActivity);
           // Liveness (#217): a socket that drops on its own must stop reading
-          // as connected. Removed again in `disconnect()`.
+          // as connected, and one that socket.io reconnects must read as
+          // connected again. Both are removed in `disconnect()`.
+          this.socket?.on('connect', this.onSocketConnect);
           this.socket?.on('disconnect', this.onSocketDisconnect);
           resolve(worldData);
         });
@@ -366,6 +371,28 @@ export class FoundryClient {
    *
    * Bound field rather than a method so the same reference reaches `socket.off()`.
    */
+  /**
+   * Reacts to socket.io bringing the link back up on its own (#217).
+   *
+   * `sessionSocketOptions` leaves socket.io-client's default
+   * `reconnection: true` in place, so after a transient drop the manager
+   * re-handshakes the SAME socket instance (the session cookie rides along in
+   * `extraHeaders`) and the persistent `modifyDocument`/`userActivity`
+   * listeners resume firing. Without this the connected flag would stay
+   * latched off for the rest of the process while writes and broadcasts were
+   * demonstrably working again.
+   *
+   * `worldDataStale` is deliberately *not* cleared: broadcasts emitted while
+   * the socket was down were never delivered and are not replayed, so the
+   * cache stays flagged until an explicit `refreshWorldData()`.
+   *
+   * Bound field rather than a method so the same reference reaches `socket.off()`.
+   */
+  private onSocketConnect = (): void => {
+    this._isConnected = true;
+    logger.info('FoundryVTT socket reconnected — cached world data is still stale until refreshed');
+  };
+
   private onSocketDisconnect = (reason?: unknown): void => {
     this._isConnected = false;
     this.worldDataStale = this.worldData !== null;
@@ -374,14 +401,28 @@ export class FoundryClient {
     });
   };
 
-  async disconnect(): Promise<void> {
-    if (this.socket) {
-      this.socket.off('modifyDocument', this.onDocumentBroadcast);
-      this.socket.off('userActivity', this.onUserActivity);
-      this.socket.off('disconnect', this.onSocketDisconnect);
-      this.socket.disconnect();
-      this.socket = null;
+  /**
+   * Closes the current socket and removes every persistent listener bound to
+   * it. Used both by `disconnect()` and before a socket is replaced: a
+   * superseded socket that kept its `disconnect` handler would otherwise clear
+   * the connected flag of the live socket that replaced it when it finally
+   * closed (`DiagnosticsClient.testAuthentication()` re-connects a live
+   * client, so this is reachable in-repo).
+   */
+  private detachSocket(): void {
+    if (!this.socket) {
+      return;
     }
+    this.socket.off('modifyDocument', this.onDocumentBroadcast);
+    this.socket.off('userActivity', this.onUserActivity);
+    this.socket.off('connect', this.onSocketConnect);
+    this.socket.off('disconnect', this.onSocketDisconnect);
+    this.socket.disconnect();
+    this.socket = null;
+  }
+
+  async disconnect(): Promise<void> {
+    this.detachSocket();
     this.worldData = null;
     this.worldDataStale = false;
     this._isConnected = false;
@@ -394,7 +435,9 @@ export class FoundryClient {
    * Socket.IO mode answers from the socket itself rather than from a latched
    * flag, so a link that dropped without an explicit `disconnect()` — server
    * restart, network loss — reads as disconnected immediately, even if the
-   * `disconnect` event has not been delivered yet.
+   * `disconnect` event has not been delivered yet. It tracks the socket in both
+   * directions: an automatic reconnect (`onSocketConnect`) reads as connected
+   * again rather than staying latched off.
    *
    * REST API mode (`FOUNDRY_API_KEY`) has no socket at all: there the connect
    * probe against `/api/status` is the only liveness signal there is, so the

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -117,6 +117,21 @@ const TOKEN_ACTOR_UUID_PATTERN =
   /^(Actor\.[a-zA-Z0-9]{16}|Scene\.[a-zA-Z0-9]{16}\.Token\.[a-zA-Z0-9]{16}\.Actor\.[a-zA-Z0-9]{16})$/;
 
 /**
+ * Minimal Zod schema for the `/api/dice/roll` REST response.
+ *
+ * The REST module is external input, so the body is validated rather than read
+ * off an `any`: a 200 whose payload carries no numeric `total` would otherwise
+ * produce a `DiceRoll` with `total: undefined` while the type claims `number`,
+ * and `roll_dice` would render that straight to the caller. A body that does
+ * not match is treated like any other REST failure and falls through to the
+ * local roller.
+ */
+const RestDiceRollSchema = z.object({
+  total: z.number(),
+  terms: z.array(z.object({ results: z.array(z.number()).optional() })).optional(),
+});
+
+/**
  * Minimal Zod schema for the WorldData Socket.IO payload.
  * Validates the required top-level array fields; extra fields pass through.
  */
@@ -1558,13 +1573,12 @@ export class FoundryClient {
           flavor: reason,
         });
 
+        const rolled = RestDiceRollSchema.parse(response.data);
+
         const result: DiceRoll = {
           formula,
-          total: response.data.total,
-          breakdown:
-            response.data.terms
-              ?.map((term: { results?: number[] }) => term.results?.join(', '))
-              .join(' + ') || formula,
+          total: rolled.total,
+          breakdown: rolled.terms?.map((term) => term.results?.join(', ')).join(' + ') || formula,
           timestamp: new Date().toISOString(),
         };
         if (reason) {

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -54,8 +54,35 @@ const FOUNDRY_ID_PATTERN = /^[a-zA-Z0-9]{16}$/;
  */
 const DICE_FORMULA_ALPHABET = /^[0-9d\s+\-()]+$/;
 
+/** Single-character form of {@link DICE_FORMULA_ALPHABET}, for locating a violation. */
+const DICE_FORMULA_CHARACTER = /[0-9d\s+\-()]/;
+
 /** Upper bound on formula length, common to both transports. */
 const MAX_DICE_FORMULA_LENGTH = 100;
+
+/**
+ * Builds the REST-path rejection for a formula outside the dice alphabet.
+ *
+ * The local parser cannot be borrowed for this: it rejects parentheses, which
+ * REST *does* support, so for `(1d20+5)*2` it would name the wrong problem.
+ * This scans for the first character the alphabet does not admit and reports
+ * it by name and position, so the REST path is as specific about what it
+ * refused as the local one (#219).
+ */
+function alphabetViolation(formula: string): Error {
+  if (formula === '') {
+    return new Error('Invalid dice formula: the formula is empty.');
+  }
+  const index = [...formula].findIndex((char) => !DICE_FORMULA_CHARACTER.test(char));
+  if (index === -1) {
+    return new Error(`Invalid dice formula: ${formula}`);
+  }
+  return new Error(
+    `Invalid dice formula "${formula}": unexpected "${formula[index]}" at position ${index}. ` +
+      'Supported syntax: dice terms (NdS, or dS for a single die) and whole numbers, joined by ' +
+      '+ or -, optionally grouped in parentheses.',
+  );
+}
 
 /**
  * True when a rejected request carries an HTTP response — FoundryVTT answered,
@@ -1499,7 +1526,10 @@ export class FoundryClient {
    *    where FoundryVTT's own `Roll` engine evaluates it. That engine
    *    understands more than this module does — parentheses, for one — so only
    *    {@link DICE_FORMULA_ALPHABET} applies here. Imposing the local parser's
-   *    narrower grammar would take away a capability the transport has.
+   *    narrower grammar would take away a capability the transport has. What
+   *    the alphabet does refuse is refused by name and position
+   *    (`unexpected "k" at position 3`, see {@link alphabetViolation}), so the
+   *    two transports are equally specific about what they would not evaluate.
    *  - **Socket.IO / no API key** has no remote evaluator: `fallbackDiceRoll`
    *    is the roller, so the grammar its parser can represent is the grammar
    *    accepted, and that parser is the *only* gate. No alphabet pre-check runs
@@ -1519,7 +1549,7 @@ export class FoundryClient {
 
     if (this.config.apiKey) {
       if (!formula || !DICE_FORMULA_ALPHABET.test(formula)) {
-        throw new Error(`Invalid dice formula: ${formula}`);
+        throw alphabetViolation(formula);
       }
 
       try {

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -58,6 +58,22 @@ const DICE_FORMULA_ALPHABET = /^[0-9d\s+\-()]+$/;
 const MAX_DICE_FORMULA_LENGTH = 100;
 
 /**
+ * True when a rejected request carries an HTTP response — FoundryVTT answered,
+ * whatever the status. A rejection without one is a transport failure
+ * (connection refused or reset, DNS, timeout): the server is not reachable.
+ *
+ * Read reflectively rather than cast, so a non-axios rejection cannot be
+ * mistaken for a reply.
+ */
+function hasHttpResponse(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+  const response = Reflect.get(error, 'response');
+  return response !== undefined && response !== null;
+}
+
+/**
  * Spacing between sibling `sort` values, mirroring Foundry's
  * `CONST.SORT_INTEGER_DENSITY`. Leaving every sibling at the default `0` makes
  * ordering depend on incidental collection insertion order, and gives Foundry
@@ -158,6 +174,11 @@ export class FoundryClient {
   private worldData: WorldData | null = null;
   /** Set when the socket drops with a cache still loaded (#217). */
   private worldDataStale = false;
+  /**
+   * Last observed outcome of a REST request: false once one failed to reach
+   * FoundryVTT at all (#217). Unused in Socket.IO mode.
+   */
+  private restLinkLive = true;
 
   constructor(config: FoundryClientConfig) {
     if (!config.baseUrl || config.baseUrl.trim() === '') {
@@ -196,6 +217,19 @@ export class FoundryClient {
         reqConfig.headers['x-api-key'] = this.config.apiKey;
         return reqConfig;
       });
+
+      // REST mode has no socket to ask about liveness, so every request that
+      // does happen doubles as the probe (#217). See `isConnected()`.
+      this.http.interceptors.response.use(
+        (response) => {
+          this.restLinkLive = true;
+          return response;
+        },
+        (error: unknown) => {
+          this.restLinkLive = hasHttpResponse(error);
+          return Promise.reject(error);
+        },
+      );
     }
 
     const mode = this.config.apiKey ? 'REST API' : 'Socket.IO';
@@ -438,6 +472,7 @@ export class FoundryClient {
     this.worldData = null;
     this.worldDataStale = false;
     this._isConnected = false;
+    this.restLinkLive = true;
     logger.info('FoundryVTT client disconnected');
   }
 
@@ -451,13 +486,18 @@ export class FoundryClient {
    * directions: an automatic reconnect (`onSocketConnect`) reads as connected
    * again rather than staying latched off.
    *
-   * REST API mode (`FOUNDRY_API_KEY`) has no socket at all: there the connect
-   * probe against `/api/status` is the only liveness signal there is, so the
-   * flag stands on its own.
+   * REST API mode (`FOUNDRY_API_KEY`) has no socket to ask, so it answers from
+   * the last REST request that actually happened: a request that failed to
+   * reach FoundryVTT (connection refused, reset, timed out) reads as
+   * disconnected from then on, and the next request that gets through reads as
+   * connected again. An HTTP error status does not count as a drop — the
+   * server answered. This is a *last observed outcome*, not a live probe: it
+   * cannot notice a server that went away between requests, and it never does
+   * I/O of its own, because this accessor is synchronous and widely called.
    */
   isConnected(): boolean {
     if (this.config.apiKey) {
-      return this._isConnected;
+      return this._isConnected && this.restLinkLive;
     }
     return this._isConnected && this.socket?.connected === true;
   }

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -34,7 +34,12 @@ import type {
   WorldUser,
 } from './types.js';
 import { VISIBILITY_LEVELS } from './types.js';
-import { applyDocumentBroadcast, parseDocumentBroadcast } from './world-cache.js';
+import {
+  applyDocumentBroadcast,
+  applyUserActivity,
+  parseDocumentBroadcast,
+  parseUserActivity,
+} from './world-cache.js';
 
 /** FoundryVTT document IDs are 16-character alphanumeric strings. */
 const FOUNDRY_ID_PATTERN = /^[a-zA-Z0-9]{16}$/;
@@ -261,6 +266,9 @@ export class FoundryClient {
           // Keep the snapshot live from here on (#205). Attached only after a
           // successful handshake so the reject paths have no listener to leak.
           this.socket?.on('modifyDocument', this.onDocumentBroadcast);
+          // Presence (#218): `activeUsers` is not a document collection, so it
+          // only moves on this event.
+          this.socket?.on('userActivity', this.onUserActivity);
           // Liveness (#217): a socket that drops on its own must stop reading
           // as connected. Removed again in `disconnect()`.
           this.socket?.on('disconnect', this.onSocketDisconnect);
@@ -313,6 +321,36 @@ export class FoundryClient {
   };
 
   /**
+   * Applies a FoundryVTT `userActivity` broadcast to cached presence (#218).
+   *
+   * Foundry emits this on login, on logout, and on ordinary activity, and it is
+   * the only signal that moves `worldData.activeUsers` — that field is a
+   * top-level `WorldData` entry, not a document collection, so the
+   * `modifyDocument` path never touches it and `get_users` would otherwise
+   * answer "who is connected?" from the connect-time snapshot forever.
+   *
+   * Bound field rather than a method so the same reference reaches `socket.off()`.
+   * Never throws: an unrecognized payload leaves presence as it was.
+   */
+  private onUserActivity = (userId: unknown, activityData?: unknown): void => {
+    if (!this.worldData) {
+      return;
+    }
+
+    const activity = parseUserActivity(userId, activityData);
+    if (!activity) {
+      logger.debug('Ignored unrecognized userActivity payload');
+      return;
+    }
+
+    if (applyUserActivity(this.worldData, activity)) {
+      logger.debug(
+        `User ${activity.userId} is now ${activity.active ? 'active' : 'inactive'} (userActivity)`,
+      );
+    }
+  };
+
+  /**
    * Reacts to the socket dropping on its own — server restart, network loss,
    * an idle timeout (#217).
    *
@@ -338,6 +376,7 @@ export class FoundryClient {
   async disconnect(): Promise<void> {
     if (this.socket) {
       this.socket.off('modifyDocument', this.onDocumentBroadcast);
+      this.socket.off('userActivity', this.onUserActivity);
       this.socket.off('disconnect', this.onSocketDisconnect);
       this.socket.disconnect();
       this.socket = null;

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -1525,10 +1525,10 @@ export class FoundryClient {
    *  - **REST (`FOUNDRY_API_KEY`)** posts the formula to `/api/dice/roll`,
    *    where FoundryVTT's own `Roll` engine evaluates it. That engine
    *    understands more than this module does — parentheses, for one — so only
-   *    {@link DICE_FORMULA_ALPHABET} applies here. Imposing the local parser's
-   *    narrower grammar would take away a capability the transport has. What
-   *    the alphabet does refuse is refused by name and position
-   *    (`unexpected "k" at position 3`, see {@link alphabetViolation}), so the
+   *    the `DICE_FORMULA_ALPHABET` check applies here. Imposing the local
+   *    parser's narrower grammar would take away a capability the transport
+   *    has. What the alphabet does refuse is refused by name and position
+   *    (`unexpected "k" at position 3`, via `alphabetViolation`), so the
    *    two transports are equally specific about what they would not evaluate.
    *  - **Socket.IO / no API key** has no remote evaluator: `fallbackDiceRoll`
    *    is the roller, so the grammar its parser can represent is the grammar

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -10,6 +10,7 @@ import { io, type Socket } from 'socket.io-client';
 import { z } from 'zod';
 import { logger } from '../utils/logger.js';
 import { authenticateFoundry, sessionSocketOptions } from './auth.js';
+import { evaluateDiceFormula, parseDiceFormula } from './dice-formula.js';
 import type {
   ActorAttributeUpdateResult,
   ActorItemCreateSource,
@@ -1393,11 +1394,26 @@ export class FoundryClient {
   // Dice rolling
   // ==========================================================================
 
+  /**
+   * Rolls a dice formula.
+   *
+   * Two gates apply, and they agree on the accepted language (#219): the
+   * character class below is a cheap sanity check that rejects anything outside
+   * the alphabet (Foundry modifier syntax like `4d6kh3`, `1d20+STR`, `*`), and
+   * {@link parseDiceFormula} — run before either transport, so REST and the
+   * local roller accept exactly the same formulas — is the authority on the
+   * grammar. Anything the parser cannot represent throws a specific error; no
+   * term is ever dropped from a total in silence.
+   */
   async rollDice(formula: string, reason?: string): Promise<DiceRoll> {
     const DICE_FORMULA_REGEX = /^[0-9d\s+\-()]+$/;
     if (!formula || formula.length > 100 || !DICE_FORMULA_REGEX.test(formula)) {
       throw new Error(`Invalid dice formula: ${formula}`);
     }
+    // Throws on anything the grammar cannot represent — parentheses, a dangling
+    // operator, a zero-sided die — rather than letting it reach a roller that
+    // would quietly ignore it.
+    parseDiceFormula(formula);
 
     if (this.config.apiKey) {
       try {
@@ -1427,33 +1443,19 @@ export class FoundryClient {
     return this.fallbackDiceRoll(formula, reason);
   }
 
+  /**
+   * Rolls locally, when FoundryVTT is not doing it for us.
+   *
+   * Delegates the whole formula to {@link evaluateDiceFormula}, which consumes
+   * the input end to end and throws on any leftover it cannot represent (#219).
+   */
   private fallbackDiceRoll(formula: string, reason?: string): DiceRoll {
-    const diceRegex = /(\d+)d(\d+)([+-]\d+)?/g;
-    let total = 0;
-    const breakdown: string[] = [];
-
-    let match: RegExpExecArray | null = diceRegex.exec(formula);
-    while (match !== null) {
-      const [, numDice, numSides, modifier] = match;
-      const diceCount = parseInt(numDice || '1', 10);
-      const sides = parseInt(numSides || '6', 10);
-      const mod = modifier ? parseInt(modifier, 10) : 0;
-
-      const rolls: number[] = [];
-      for (let i = 0; i < diceCount; i++) {
-        rolls.push(Math.floor(Math.random() * sides) + 1);
-      }
-
-      const rollSum = rolls.reduce((sum, roll) => sum + roll, 0) + mod;
-      total += rollSum;
-      breakdown.push(`${rolls.join(', ')}${mod !== 0 ? ` ${modifier}` : ''} = ${rollSum}`);
-      match = diceRegex.exec(formula);
-    }
+    const { total, breakdown } = evaluateDiceFormula(formula);
 
     const result: DiceRoll = {
       formula,
       total,
-      breakdown: breakdown.join(' | '),
+      breakdown,
       timestamp: new Date().toISOString(),
     };
     if (reason) {

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -10,7 +10,7 @@ import { io, type Socket } from 'socket.io-client';
 import { z } from 'zod';
 import { logger } from '../utils/logger.js';
 import { authenticateFoundry, sessionSocketOptions } from './auth.js';
-import { evaluateDiceFormula, parseDiceFormula } from './dice-formula.js';
+import { evaluateDiceFormula } from './dice-formula.js';
 import type {
   ActorAttributeUpdateResult,
   ActorItemCreateSource,
@@ -44,6 +44,18 @@ import {
 
 /** FoundryVTT document IDs are 16-character alphanumeric strings. */
 const FOUNDRY_ID_PATTERN = /^[a-zA-Z0-9]{16}$/;
+
+/**
+ * Characters a dice formula may contain. A cheap sanity gate, not a grammar:
+ * it rejects Foundry modifier syntax (`4d6kh3`), attribute references
+ * (`1d20+STR`) and arithmetic this server never forwards (`*`, `/`), while
+ * still allowing parentheses through to FoundryVTT's own `Roll` engine on the
+ * REST transport. See {@link FoundryClient.rollDice}.
+ */
+const DICE_FORMULA_ALPHABET = /^[0-9d\s+\-()]+$/;
+
+/** Upper bound on formula length, common to both transports. */
+const MAX_DICE_FORMULA_LENGTH = 100;
 
 /**
  * Spacing between sibling `sort` values, mirroring Foundry's
@@ -1440,25 +1452,36 @@ export class FoundryClient {
   /**
    * Rolls a dice formula.
    *
-   * Two gates apply, and they agree on the accepted language (#219): the
-   * character class below is a cheap sanity check that rejects anything outside
-   * the alphabet (Foundry modifier syntax like `4d6kh3`, `1d20+STR`, `*`), and
-   * {@link parseDiceFormula} — run before either transport, so REST and the
-   * local roller accept exactly the same formulas — is the authority on the
-   * grammar. Anything the parser cannot represent throws a specific error; no
-   * term is ever dropped from a total in silence.
+   * Validation is deliberately **per transport**, because the two transports
+   * are not equally capable (#219):
+   *
+   *  - **REST (`FOUNDRY_API_KEY`)** posts the formula to `/api/dice/roll`,
+   *    where FoundryVTT's own `Roll` engine evaluates it. That engine
+   *    understands more than this module does — parentheses, for one — so only
+   *    {@link DICE_FORMULA_ALPHABET} applies here. Imposing the local parser's
+   *    narrower grammar would take away a capability the transport has.
+   *  - **Socket.IO / no API key** has no remote evaluator: `fallbackDiceRoll`
+   *    is the roller, so the grammar its parser can represent is the grammar
+   *    accepted, and that parser is the *only* gate. No alphabet pre-check runs
+   *    ahead of it, so its specific message (`unexpected "k" at position 3`)
+   *    reaches the caller instead of a generic `Invalid dice formula: 4d6kh3`.
+   *    Nothing is ever dropped from a total in silence.
+   *
+   * The length cap is common to both. A REST roll that cannot reach FoundryVTT
+   * falls through to the local roller, which then applies the strict grammar —
+   * a formula only Foundry could evaluate errors out rather than being
+   * mis-totalled locally.
    */
   async rollDice(formula: string, reason?: string): Promise<DiceRoll> {
-    const DICE_FORMULA_REGEX = /^[0-9d\s+\-()]+$/;
-    if (!formula || formula.length > 100 || !DICE_FORMULA_REGEX.test(formula)) {
+    if (typeof formula !== 'string' || formula.length > MAX_DICE_FORMULA_LENGTH) {
       throw new Error(`Invalid dice formula: ${formula}`);
     }
-    // Throws on anything the grammar cannot represent — parentheses, a dangling
-    // operator, a zero-sided die — rather than letting it reach a roller that
-    // would quietly ignore it.
-    parseDiceFormula(formula);
 
     if (this.config.apiKey) {
+      if (!formula || !DICE_FORMULA_ALPHABET.test(formula)) {
+        throw new Error(`Invalid dice formula: ${formula}`);
+      }
+
       try {
         const response = await this.http.post('/api/dice/roll', {
           formula,

--- a/src/foundry/client.ts
+++ b/src/foundry/client.ts
@@ -138,6 +138,8 @@ export class FoundryClient {
   private config: FoundryClientConfig;
   private _isConnected = false;
   private worldData: WorldData | null = null;
+  /** Set when the socket drops with a cache still loaded (#217). */
+  private worldDataStale = false;
 
   constructor(config: FoundryClientConfig) {
     if (!config.baseUrl || config.baseUrl.trim() === '') {
@@ -212,6 +214,7 @@ export class FoundryClient {
 
     // Connect authenticated socket and load world data
     this.worldData = await this.connectAndLoadWorld(session);
+    this.worldDataStale = false;
     this._isConnected = true;
     logger.info('Connected to FoundryVTT via Socket.IO', {
       actors: this.worldData.actors.length,
@@ -258,6 +261,9 @@ export class FoundryClient {
           // Keep the snapshot live from here on (#205). Attached only after a
           // successful handshake so the reject paths have no listener to leak.
           this.socket?.on('modifyDocument', this.onDocumentBroadcast);
+          // Liveness (#217): a socket that drops on its own must stop reading
+          // as connected. Removed again in `disconnect()`.
+          this.socket?.on('disconnect', this.onSocketDisconnect);
           resolve(worldData);
         });
       };
@@ -306,19 +312,68 @@ export class FoundryClient {
     }
   };
 
+  /**
+   * Reacts to the socket dropping on its own — server restart, network loss,
+   * an idle timeout (#217).
+   *
+   * Clears the connected flag so `isConnected()` and `get_health_status` stop
+   * claiming a live link, and marks the cached snapshot stale: nothing is
+   * applying `modifyDocument` broadcasts while the socket is down, so whatever
+   * is in `worldData` from here on is a point-in-time copy, not live state.
+   * The cache is deliberately *kept* rather than dropped — a stale answer with
+   * an honest connection line beats no answer at all — and Socket.IO's own
+   * reconnect logic may bring the link back, at which point `refreshWorldData()`
+   * resyncs it.
+   *
+   * Bound field rather than a method so the same reference reaches `socket.off()`.
+   */
+  private onSocketDisconnect = (reason?: unknown): void => {
+    this._isConnected = false;
+    this.worldDataStale = this.worldData !== null;
+    logger.warn('FoundryVTT socket disconnected — cached world data is now stale', {
+      reason: typeof reason === 'string' ? reason : undefined,
+    });
+  };
+
   async disconnect(): Promise<void> {
     if (this.socket) {
       this.socket.off('modifyDocument', this.onDocumentBroadcast);
+      this.socket.off('disconnect', this.onSocketDisconnect);
       this.socket.disconnect();
       this.socket = null;
     }
     this.worldData = null;
+    this.worldDataStale = false;
     this._isConnected = false;
     logger.info('FoundryVTT client disconnected');
   }
 
+  /**
+   * Reports whether the client currently has a live link to FoundryVTT (#217).
+   *
+   * Socket.IO mode answers from the socket itself rather than from a latched
+   * flag, so a link that dropped without an explicit `disconnect()` — server
+   * restart, network loss — reads as disconnected immediately, even if the
+   * `disconnect` event has not been delivered yet.
+   *
+   * REST API mode (`FOUNDRY_API_KEY`) has no socket at all: there the connect
+   * probe against `/api/status` is the only liveness signal there is, so the
+   * flag stands on its own.
+   */
   isConnected(): boolean {
-    return this._isConnected;
+    if (this.config.apiKey) {
+      return this._isConnected;
+    }
+    return this._isConnected && this.socket?.connected === true;
+  }
+
+  /**
+   * True when the cached snapshot is no longer being kept live by broadcasts —
+   * i.e. the socket dropped after a world load (#217). Reads still answer from
+   * the cache; this flags that the answer is a point-in-time copy.
+   */
+  isWorldDataStale(): boolean {
+    return this.worldDataStale;
   }
 
   /**
@@ -374,6 +429,7 @@ export class FoundryClient {
       this.socket?.emit('world');
     });
 
+    this.worldDataStale = false;
     logger.info('World data refreshed', {
       actors: this.worldData.actors.length,
       items: this.worldData.items.length,

--- a/src/foundry/dice-formula.ts
+++ b/src/foundry/dice-formula.ts
@@ -1,0 +1,216 @@
+/**
+ * @fileoverview Dice formula parsing and evaluation for the local roller (#219).
+ *
+ * The local roller used to scan a formula with `/(\d+)d(\d+)([+-]\d+)?/g`, which
+ * only captures a modifier glued directly to a dice term. Everything else the
+ * caller's character-class validator let through — a space-separated modifier
+ * (`1d20 + 5`), a second bonus (`1d20+5+3`), a count-less die (`d20`), a second
+ * dice term (`2d6+1d4`), parentheses — was silently dropped from the total. A
+ * dropped term produces a plausible number that is simply wrong, which for a
+ * dice roller is worse than an error: nothing signals that the formula was not
+ * understood.
+ *
+ * So this module does two things, in this order of importance:
+ *  1. Parses the whole formula into dice terms and standalone constants.
+ *  2. Consumes the input end to end, and throws a specific error on anything it
+ *     cannot represent. Nothing is ever dropped in silence.
+ *
+ * The supported grammar is deliberately small:
+ *
+ *     formula  := sign? term ( sign term )*
+ *     term     := dice | constant
+ *     dice     := digit* 'd' digit+          // a missing count means 1
+ *     constant := digit+
+ *     sign     := '+' | '-'
+ *
+ * Parentheses, multiplication and Foundry's modifier syntax (`4d6kh3`, `1d20r1`)
+ * are NOT supported and are rejected by name rather than ignored.
+ */
+
+/** A dice term such as `2d6`, carried with the sign that precedes it. */
+export interface DiceFormulaDiceTerm {
+  kind: 'dice';
+  sign: 1 | -1;
+  count: number;
+  sides: number;
+}
+
+/** A standalone whole-number constant such as the `5` in `1d20 + 5`. */
+export interface DiceFormulaConstantTerm {
+  kind: 'constant';
+  sign: 1 | -1;
+  value: number;
+}
+
+export type DiceFormulaTerm = DiceFormulaDiceTerm | DiceFormulaConstantTerm;
+
+/** A term after evaluation: the same shape plus the rolls and the subtotal. */
+export type RolledTerm =
+  | (DiceFormulaDiceTerm & { rolls: number[]; value: number })
+  | (DiceFormulaConstantTerm & { rolls?: undefined });
+
+export interface DiceFormulaResult {
+  /** Signed sum of every term — never a partial total. */
+  total: number;
+  /** Human-readable rendering, e.g. `2d6: [3, 5] + 1d4: [2] = 10`. */
+  breakdown: string;
+  terms: RolledTerm[];
+}
+
+/**
+ * Upper bound on dice per term. A formula is capped at 100 characters upstream,
+ * which still allows five-digit counts; rolling those is pointless and slow, so
+ * it is refused explicitly rather than attempted.
+ */
+export const MAX_DICE_PER_TERM = 1000;
+
+/** Matches one term at a fixed offset: `NdS`, `dS`, or a bare constant. */
+const TERM_PATTERN = /(\d*)d(\d+)|(\d+)/y;
+
+function invalid(formula: string, detail: string): Error {
+  return new Error(`Invalid dice formula "${formula}": ${detail}`);
+}
+
+function isWhitespace(char: string | undefined): boolean {
+  return char !== undefined && /\s/.test(char);
+}
+
+/**
+ * Parses a dice formula into its terms.
+ *
+ * @throws {Error} if the formula is empty, or holds anything the grammar above
+ *   cannot represent. The message names the offending formula and what was
+ *   wrong with it.
+ */
+export function parseDiceFormula(formula: string): DiceFormulaTerm[] {
+  if (typeof formula !== 'string' || formula.trim() === '') {
+    throw new Error('Invalid dice formula: the formula is empty.');
+  }
+
+  if (formula.includes('(') || formula.includes(')')) {
+    throw new Error(
+      `Unsupported dice formula "${formula}": parentheses are not supported. ` +
+        'Expand the expression into plain terms joined by + or - (e.g. "1d20+5").',
+    );
+  }
+
+  const terms: DiceFormulaTerm[] = [];
+  let index = 0;
+  let sign: 1 | -1 = 1;
+
+  const skipWhitespace = () => {
+    while (isWhitespace(formula[index])) {
+      index += 1;
+    }
+  };
+
+  skipWhitespace();
+  if (formula[index] === '+' || formula[index] === '-') {
+    sign = formula[index] === '-' ? -1 : 1;
+    index += 1;
+    skipWhitespace();
+  }
+
+  for (;;) {
+    if (index >= formula.length) {
+      throw invalid(formula, 'it ends with a dangling operator.');
+    }
+
+    TERM_PATTERN.lastIndex = index;
+    const match = TERM_PATTERN.exec(formula);
+    if (!match) {
+      throw invalid(
+        formula,
+        `unexpected "${formula[index]}" at position ${index}. Supported syntax: dice terms ` +
+          '(NdS, or dS for a single die) and whole numbers, joined by + or -.',
+      );
+    }
+    index = TERM_PATTERN.lastIndex;
+
+    const [, rawCount, rawSides, rawConstant] = match;
+    if (rawSides !== undefined) {
+      // A missing count means one die: "d20" is "1d20".
+      const count = rawCount === '' || rawCount === undefined ? 1 : Number.parseInt(rawCount, 10);
+      const sides = Number.parseInt(rawSides, 10);
+      if (sides < 1) {
+        throw invalid(formula, 'a die must have at least 1 side.');
+      }
+      if (count > MAX_DICE_PER_TERM) {
+        throw invalid(
+          formula,
+          `too many dice (${count}); the limit is ${MAX_DICE_PER_TERM} per term.`,
+        );
+      }
+      terms.push({ kind: 'dice', sign, count, sides });
+    } else {
+      terms.push({ kind: 'constant', sign, value: Number.parseInt(rawConstant ?? '0', 10) });
+    }
+
+    skipWhitespace();
+    if (index >= formula.length) {
+      return terms;
+    }
+
+    const operator = formula[index];
+    if (operator !== '+' && operator !== '-') {
+      throw invalid(
+        formula,
+        `unexpected "${operator}" at position ${index}; terms must be joined by + or -.`,
+      );
+    }
+    sign = operator === '-' ? -1 : 1;
+    index += 1;
+    skipWhitespace();
+  }
+}
+
+/** Renders one evaluated term, e.g. `2d6: [3, 5]` or `5`. */
+function renderTerm(term: RolledTerm): string {
+  return term.kind === 'dice'
+    ? `${term.count}d${term.sides}: [${term.rolls.join(', ')}]`
+    : `${term.value}`;
+}
+
+/**
+ * Rolls a formula and returns the total together with the terms that produced it.
+ *
+ * @param formula - Formula in the grammar documented above.
+ * @param rng - Uniform [0, 1) source; injectable so tests can be deterministic.
+ * @throws {Error} for any formula {@link parseDiceFormula} cannot represent.
+ */
+export function evaluateDiceFormula(
+  formula: string,
+  rng: () => number = Math.random,
+): DiceFormulaResult {
+  const parsed = parseDiceFormula(formula);
+  const terms: RolledTerm[] = [];
+  let total = 0;
+
+  for (const term of parsed) {
+    if (term.kind === 'constant') {
+      total += term.sign * term.value;
+      terms.push(term);
+      continue;
+    }
+
+    const rolls: number[] = [];
+    for (let i = 0; i < term.count; i += 1) {
+      rolls.push(Math.floor(rng() * term.sides) + 1);
+    }
+    const value = rolls.reduce((sum, roll) => sum + roll, 0);
+    total += term.sign * value;
+    terms.push({ ...term, rolls, value });
+  }
+
+  const rendered = terms
+    .map((term, position) => {
+      const body = renderTerm(term);
+      if (position === 0) {
+        return term.sign === -1 ? `-${body}` : body;
+      }
+      return `${term.sign === -1 ? '-' : '+'} ${body}`;
+    })
+    .join(' ');
+
+  return { total, breakdown: `${rendered} = ${total}`, terms };
+}

--- a/src/foundry/types.ts
+++ b/src/foundry/types.ts
@@ -876,7 +876,17 @@ export interface WorldCombat {
   active: boolean;
   round: number;
   turn: number | null;
-  started: boolean;
+  /**
+   * **Not persisted by FoundryVTT — do not gate behaviour on it.**
+   *
+   * `Combat#started` is a client-side derived getter (`turns.length > 0 &&
+   * round > 0`); `BaseCombat.defineSchema()` never declares it, so a document
+   * arriving in the `world` socket payload (validated only as
+   * `z.array(z.unknown())` and cast, see `client.ts`) carries no such key.
+   * Optional here so the compiler cannot imply the transport provides it —
+   * derive started-ness from `round` and `combatants` instead.
+   */
+  started?: boolean;
   combatants: Array<{
     _id: string;
     actorId?: string;

--- a/src/foundry/world-cache.ts
+++ b/src/foundry/world-cache.ts
@@ -16,6 +16,7 @@
  * broadcast twice lands on the same state as applying it once.
  */
 
+import { z } from 'zod';
 import type { WorldActor, WorldCombat, WorldData, WorldScene } from './types.js';
 
 /** A `modifyDocument` broadcast, once validated. */
@@ -301,4 +302,76 @@ export function applyDocumentBroadcast(
   }
 
   return applyToCollection(collection as Array<Record<string, unknown>>, action, result);
+}
+
+// ============================================================================
+// User presence (`userActivity`) — #218
+// ============================================================================
+
+/** A validated `userActivity` broadcast: who, and whether they are present. */
+export interface UserActivity {
+  userId: string;
+  active: boolean;
+}
+
+/**
+ * FoundryVTT's `userActivity` payload, as far as presence is concerned.
+ *
+ * The event carries a grab-bag of ephemeral state (cursor position, ruler,
+ * targets, active scene). Only `active` matters here; everything else is
+ * accepted and ignored. The flag is absent on ordinary activity pings — Foundry
+ * itself treats "no flag" as "present", so the parser defaults to `true`.
+ */
+const UserActivityDataSchema = z.object({ active: z.boolean().optional() });
+
+/**
+ * Validates a raw `userActivity` socket payload (#218).
+ *
+ * This is untrusted network data, so it is schema-checked rather than cast.
+ * Returns `null` for anything unrecognized, leaving presence as it was.
+ */
+export function parseUserActivity(userId: unknown, activityData: unknown): UserActivity | null {
+  if (typeof userId !== 'string' || !userId) {
+    return null;
+  }
+  if (activityData === undefined || activityData === null) {
+    return { userId, active: true };
+  }
+
+  const parsed = UserActivityDataSchema.safeParse(activityData);
+  if (!parsed.success) {
+    return null;
+  }
+  return { userId, active: parsed.data.active ?? true };
+}
+
+/**
+ * Applies a presence change to `worldData.activeUsers`, in place.
+ *
+ * `activeUsers` is a top-level `WorldData` field rather than a document
+ * collection, which is exactly why `modifyDocument` broadcasts never reached it
+ * and presence stayed frozen at the connect-time snapshot (#218).
+ *
+ * @returns true if the active-user list changed
+ */
+export function applyUserActivity(worldData: WorldData, activity: UserActivity): boolean {
+  if (!Array.isArray(worldData.activeUsers)) {
+    worldData.activeUsers = [];
+  }
+
+  const index = worldData.activeUsers.indexOf(activity.userId);
+
+  if (activity.active) {
+    if (index !== -1) {
+      return false;
+    }
+    worldData.activeUsers.push(activity.userId);
+    return true;
+  }
+
+  if (index === -1) {
+    return false;
+  }
+  worldData.activeUsers.splice(index, 1);
+  return true;
 }

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -31,7 +31,7 @@ const CONFIRM_FIRST =
  * *listed*, so a divergence would be invisible.
  */
 export const ROLL_DICE_DESCRIPTION =
-  'Roll dice and return the total with a per-term breakdown. A formula is dice terms and whole numbers joined by + or -, with whitespace allowed anywhere ("1d20+5", "1d20 + 5", "1d20+5+3", "2d6 + 1d4", "3d6"; a count-less "d20" means one die), and every term counts towards the total. Anything outside that grammar - parentheses, multiplication, and Foundry modifier syntax such as "4d6kh3" or "1d20r1" - is rejected with an error naming the problem, never dropped from the total in silence. Use when: the user asks for a check, save, attack, damage, or any random result.';
+  'Roll dice and return the total with a per-term breakdown. Dice terms and whole numbers joined by + or -, with whitespace allowed anywhere ("1d20+5", "1d20 + 5", "1d20+5+3", "2d6 + 1d4", "3d6"; a count-less "d20" means one die), always work and every term counts towards the total - that is the portable grammar, safe on either transport. Multiplication and Foundry modifier syntax such as "4d6kh3" or "1d20r1" are rejected on both transports, with an error naming the offending character and its position, never dropped from the total in silence. Parentheses are the one difference: with FOUNDRY_API_KEY set the formula goes to FoundryVTT\'s own Roll engine, which evaluates them, while the default Socket.IO transport rolls locally and rejects them by name - and a REST roll that cannot reach the server falls back to that same local roller, so a parenthesised formula can still fail there. Prefer the expanded form when it matters. Use when: the user asks for a check, save, attack, damage, or any random result.';
 
 /**
  * Dice rolling tool definitions
@@ -498,7 +498,7 @@ export const diagnosticsTools = [
   {
     name: 'get_health_status',
     description:
-      "Get a combined health report: MCP-to-FoundryVTT connection state, world title/system/core version, and the server's health status with its active/total user counts, uptime, heap memory and recent error/warning counts. Uptime and memory are omitted when the server does not report them; CPU, disk and playtime are not reported at all. Degrades gracefully - sections that need the REST API module (FOUNDRY_API_KEY) report as unavailable rather than failing. Use when: first checking which world is loaded and whether the server reports itself healthy.",
+      "Get a combined health report: MCP-to-FoundryVTT connection state, world title/system/core version, and the server's health status with its active/total user counts, uptime, heap memory and recent error/warning counts. The world section is prefixed with a stale marker when the cached snapshot stopped following live document changes - typically a dropped connection, whose missed updates are never replayed - and refresh_world_data resyncs it. The connection line is a live read of the socket on the default Socket.IO transport, so it follows a link that drops or comes back in both directions; with FOUNDRY_API_KEY set there is no socket and it reports the outcome of the last REST request instead, not a live probe, so a server that went away between requests still reads as connected until the next request fails. Uptime and memory are omitted when the server does not report them; CPU, disk and playtime are not reported at all. Degrades gracefully - sections that need the REST API module (FOUNDRY_API_KEY) report as unavailable rather than failing. Use when: first checking which world is loaded and whether the server reports itself healthy.",
     inputSchema: {
       type: 'object',
       properties: {},
@@ -513,7 +513,7 @@ export const combatTools = [
   {
     name: 'get_combat_state',
     description:
-      "Get the active combat encounter: initiative order with each combatant's name, initiative, HP and AC, plus the current round and which combatant is up. Use when: reporting whose turn it is, or checking whether a combat is already running before start_combat. Do not use when: you need a combatantId for set_initiative - this prints names and ordinals, not ids; read the foundry://combat resource, whose JSON includes each combatant's _id.",
+      "Get the active combat encounter: initiative order with each combatant's name, initiative, HP and AC, plus the current round and which combatant is up. Use when: reporting whose turn it is, or checking whether a combat is already running before start_combat. Do not use when: you need a combatantId for set_initiative - this prints names and ordinals, not ids; read the foundry://combat resource, whose JSON includes each combatant's _id and lists combatants in this same initiative order, so the Nth entry printed here is that resource's combatants[N-1] and combat.turn indexes it directly.",
     inputSchema: {
       type: 'object',
       properties: {},
@@ -560,7 +560,7 @@ export const combatMutationTools = [
   {
     name: 'set_initiative',
     description:
-      "Set a combatant's initiative in the active combat (or in combatId when given), reordering the turn order. Use when: an initiative roll needs to be recorded or corrected for a known combatantId. Do not use when: simply moving on to the next combatant - use next_turn. " +
+      "Set a combatant's initiative in the active combat (or in combatId when given), reordering the turn order. When that reorder moves the combatant who is currently acting to a different position, the encounter's turn index is rewritten to follow them - whoever was up stays up, and the result says so - rather than leaving the marker on whoever slid into the old slot. That follow-up applies only to the active combat: a combatId naming some other encounter still records the initiative, but its turn order is not readable here and is left alone. Use when: an initiative roll needs to be recorded or corrected for a known combatantId. Do not use when: simply moving on to the next combatant - use next_turn. " +
       WRITE_GATE,
     inputSchema: {
       type: 'object',
@@ -702,7 +702,7 @@ export const userTools = [
   {
     name: 'get_users',
     description:
-      "List the world's users with their roles and online status. Online status is live: FoundryVTT's userActivity broadcasts are applied to the cached presence list as users connect and disconnect. Use when: you need to know which user holds the GM role, or who is connected right now.",
+      "List the world's users with their roles and online status. Online status is live while the Socket.IO connection is up: FoundryVTT's userActivity broadcasts are applied to the cached presence list as users connect and disconnect. It stops tracking if that connection drops and the missed changes are not replayed - get_health_status shows the snapshot as stale, and refresh_world_data resyncs it. Use when: you need to know which user holds the GM role, or who is connected right now.",
     inputSchema: {
       type: 'object',
       properties: {},
@@ -838,7 +838,7 @@ export const worldTools = [
   {
     name: 'refresh_world_data',
     description:
-      'Force a re-fetch of the cached world data from the FoundryVTT server. Reads are normally served from a cache that already follows live document changes, so this is rarely needed. Use when: a read still looks stale after an out-of-band change - notably edits to unlinked (synthetic) token actors, which the live update feed does not cover. Refreshes the cache only; it does not modify the world.',
+      'Force a re-fetch of the cached world data from the FoundryVTT server. Reads are normally served from a cache that follows live document changes for as long as the connection holds, so this is rarely needed. Use when: the connection dropped and came back - the cache stopped following changes while it was down and nothing replays them, so it stays a point-in-time copy until this runs, and get_health_status flags it as stale until then; or a read still looks stale after an out-of-band change - notably edits to unlinked (synthetic) token actors, which the live update feed does not cover. Refreshes the cache only; it does not modify the world.',
     inputSchema: {
       type: 'object',
       properties: {},

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -31,7 +31,7 @@ const CONFIRM_FIRST =
  * *listed*, so a divergence would be invisible.
  */
 export const ROLL_DICE_DESCRIPTION =
-  'Roll dice and return the total with a per-term breakdown. Write every term as NdS with any modifier attached directly to it ("1d20+5", "3d6", "2d6 + 1d4"); a count-less "d20", a modifier separated from its term by a space ("1d20 + 5"), a trailing bonus ("1d20+5+3") and parentheses are silently dropped from the total rather than rejected, so a loosely written formula returns a wrong number. Use when: the user asks for a check, save, attack, damage, or any random result.';
+  'Roll dice and return the total with a per-term breakdown. A formula is dice terms and whole numbers joined by + or -, with whitespace allowed anywhere ("1d20+5", "1d20 + 5", "1d20+5+3", "2d6 + 1d4", "3d6"; a count-less "d20" means one die), and every term counts towards the total. Anything outside that grammar - parentheses, multiplication, and Foundry modifier syntax such as "4d6kh3" or "1d20r1" - is rejected with an error naming the problem, never dropped from the total in silence. Use when: the user asks for a check, save, attack, damage, or any random result.';
 
 /**
  * Dice rolling tool definitions
@@ -449,7 +449,7 @@ export const diagnosticsTools = [
   {
     name: 'search_logs',
     description:
-      'Search the FoundryVTT server logs for a query string. Use when: hunting a specific error message, stack trace, or module name. Do not use when: you just want the latest entries - use get_recent_logs. Note: the level and limit arguments are accepted but are not applied to the search, and matched entries are not rendered - the result reports 0 results and lists no entries whatever the log contains, so get_recent_logs is currently the only tool that returns log content. Requires the REST API module (FOUNDRY_API_KEY); fails without it.',
+      'Search the FoundryVTT server logs for a query string and list the matching entries. Use when: hunting a specific error message, stack trace, or module name. Do not use when: you just want the latest entries - use get_recent_logs. The reported match count is the server\'s total for the query, while limit caps how many of those entries are rendered (default 50, hard cap 1000). Level filtering accepts info, warn and error; "debug" is not a level this log store records, so it is reported back as unsupported and no level filter is applied. Requires the REST API module (FOUNDRY_API_KEY); fails without it.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -459,12 +459,13 @@ export const diagnosticsTools = [
         },
         level: {
           type: 'string',
-          description: 'Log level filter',
+          description:
+            'Log level filter; "debug" is not recorded by this log store and is not applied',
           enum: ['debug', 'info', 'warn', 'error'],
         },
         limit: {
           type: 'number',
-          description: 'Maximum number of results',
+          description: 'Maximum number of matched entries to render (capped at 1000)',
           default: 50,
         },
       },
@@ -474,7 +475,7 @@ export const diagnosticsTools = [
   {
     name: 'get_system_health',
     description:
-      'Get the FoundryVTT server\'s overall health status (healthy, warning, or critical). That status is the only value reported: the output\'s CPU, memory, disk, uptime, connection and performance lines have no counterpart in the diagnostics response schema and always read "N/A". Use when: you want a single healthy/warning/critical verdict for the server. Do not use when: you also want connection and world status - use get_health_status. Requires the REST API module (FOUNDRY_API_KEY); fails without it.',
+      "Get the FoundryVTT server's health report: the overall status (healthy, warning, or critical), FoundryVTT and game-system versions, world id and uptime, active/total user counts with the number of GMs, active/installed module counts, connected clients, heap and RSS memory, and the log buffer size with recent error/warning counts and error rate. CPU and disk are not reported - the diagnostics response models no such fields - and the uptime and memory lines are omitted when the server does not supply them. Use when: you want the server's own view of its health. Do not use when: you also want connection and world status - use get_health_status. Requires the REST API module (FOUNDRY_API_KEY); fails without it.",
     inputSchema: {
       type: 'object',
       properties: {},
@@ -497,7 +498,7 @@ export const diagnosticsTools = [
   {
     name: 'get_health_status',
     description:
-      'Get a combined health report: MCP-to-FoundryVTT connection state, world title/system/core version, and the server\'s health status. The connection line is the last known state - it is set when the client connects and cleared only by an explicit disconnect, not by a dropped socket, so it is not a live probe. Playtime always reports 0 hours, and the CPU, memory and uptime lines always read "N/A", as the underlying responses carry none of those values. Degrades gracefully - sections that need the REST API module (FOUNDRY_API_KEY) report as unavailable rather than failing. Use when: first checking which world is loaded and whether the server reports itself healthy.',
+      "Get a combined health report: MCP-to-FoundryVTT connection state, world title/system/core version, and the server's health status with its active/total user counts, uptime, heap memory and recent error/warning counts. Uptime and memory are omitted when the server does not report them; CPU, disk and playtime are not reported at all. Degrades gracefully - sections that need the REST API module (FOUNDRY_API_KEY) report as unavailable rather than failing. Use when: first checking which world is loaded and whether the server reports itself healthy.",
     inputSchema: {
       type: 'object',
       properties: {},
@@ -701,7 +702,7 @@ export const userTools = [
   {
     name: 'get_users',
     description:
-      "List the world's users with their roles and online status. Online status is as of the last world-data load, not a live presence check - no user-activity updates are applied afterwards, so call refresh_world_data first if it matters. Use when: you need to know which user holds the GM role, or who was connected as of that load.",
+      "List the world's users with their roles and online status. Online status is live: FoundryVTT's userActivity broadcasts are applied to the cached presence list as users connect and disconnect. Use when: you need to know which user holds the GM role, or who is connected right now.",
     inputSchema: {
       type: 'object',
       properties: {},

--- a/src/tools/handlers/__tests__/combat-mutations.test.ts
+++ b/src/tools/handlers/__tests__/combat-mutations.test.ts
@@ -636,7 +636,7 @@ describe('initiative-ordered turn semantics (#214)', () => {
     expect(await readCurrentName(combat)).toBe('Charlie');
   });
 
-  it('stays consistent after set_initiative reshuffles the turn order', async () => {
+  it('keeps the same combatant acting after set_initiative reshuffles the turn order', async () => {
     const combat = makeUnsortedCombat({ turn: 0 });
     const alice = combat.combatants.find((c) => c.name === 'Alice');
     if (!alice) {
@@ -660,16 +660,174 @@ describe('initiative-ordered turn semantics (#214)', () => {
     await handleSetInitiative({ combatantId: alice._id, initiative: 1 }, client);
     expect(setCombatantInitiative).toHaveBeenCalledWith(COMBAT_ID, alice._id, 1);
 
-    // Order is now Charlie (12), Bob (5), Alice (1) — turn 0 is Charlie, and
-    // stored order (Bob, Alice, Charlie) still disagrees with it.
+    // Order is now Charlie (12), Bob (5), Alice (1). Core's `setupTurns`
+    // re-finds the combatant that was acting and re-points `turn` at it, so
+    // Alice — not whoever slid under index 0 — must still be acting.
     expect(getTurnOrder(combat).map((c) => c.name)).toEqual(['Charlie', 'Bob', 'Alice']);
-    expect(await readCurrentName(combat)).toBe('Charlie');
+    expect(updateCombat).toHaveBeenCalledWith(COMBAT_ID, { turn: 2 });
 
+    combat.turn = 2;
+    expect(await readCurrentName(combat)).toBe('Alice');
+
+    updateCombat.mockClear();
     const text = (await handleNextTurn({}, client)).content[0].text;
-    expect(text).toContain('**Now acting:** Bob');
-    expect(updateCombat).toHaveBeenCalledWith(COMBAT_ID, { turn: 1, round: 1 });
+    expect(text).toContain('**Now acting:** Charlie');
+    expect(updateCombat).toHaveBeenCalledWith(COMBAT_ID, { turn: 0, round: 2 });
 
-    combat.turn = 1;
-    expect(await readCurrentName(combat)).toBe('Bob');
+    combat.turn = 0;
+    combat.round = 2;
+    expect(await readCurrentName(combat)).toBe('Charlie');
+  });
+});
+
+// --------------------------------------------------------------------------
+// #214 follow-up: changing any initiative re-sorts the turn order underneath
+// the stored `turn` index. FoundryVTT's `Combat#setupTurns` re-finds the
+// combatant that was acting and re-points `turn` at its new index; without the
+// same re-anchor here the MCP and Foundry disagree about whose turn it is.
+// --------------------------------------------------------------------------
+describe('set_initiative re-anchors Combat#turn', () => {
+  const ALICE = 'alicealicealice1';
+  const BOB = 'bobbobbobbobbobb';
+  const CHARLIE = 'charliecharlie11';
+
+  /** stored: Bob (5), Alice (18), Charlie (12) — initiative: Alice, Charlie, Bob. */
+  const makeCombatFixture = (overrides: Partial<WorldCombat> = {}): WorldCombat => ({
+    _id: COMBAT_ID,
+    active: true,
+    round: 1,
+    turn: 0,
+    started: true,
+    combatants: [
+      { _id: BOB, name: 'Bob', initiative: 5, hidden: false, defeated: false },
+      { _id: ALICE, name: 'Alice', initiative: 18, hidden: false, defeated: false },
+      { _id: CHARLIE, name: 'Charlie', initiative: 12, hidden: false, defeated: false },
+    ],
+    ...overrides,
+  });
+
+  /** Client whose `setCombatantInitiative` does NOT touch the fixture, so the
+   *  re-anchor cannot rely on the cache broadcast having landed first. */
+  const buildStaleCacheClient = (combat: WorldCombat) => {
+    const updateCombat = vi.fn();
+    const setCombatantInitiative = vi.fn();
+    const client = {
+      getCombatState: vi.fn().mockReturnValue(combat),
+      setCombatantInitiative,
+      updateCombat,
+    } as unknown as FoundryClient;
+    return { client, updateCombat, setCombatantInitiative };
+  };
+
+  it('follows the acting combatant when another combatant slides under the stored turn', async () => {
+    // Charlie is acting (initiative index 1). Bob jumps to 20 -> order becomes
+    // Bob, Alice, Charlie, so Charlie is now index 2.
+    const combat = makeCombatFixture({ turn: 1 });
+    const { client, updateCombat } = buildStaleCacheClient(combat);
+
+    await handleSetInitiative({ combatantId: BOB, initiative: 20 }, client);
+
+    expect(updateCombat).toHaveBeenCalledWith(COMBAT_ID, { turn: 2 });
+  });
+
+  it('re-anchors from the projected order even before the cache broadcast lands', async () => {
+    // The fixture is never mutated by the mocked write, so a re-anchor that
+    // re-read the cache would compute the OLD index and skip the update.
+    const combat = makeCombatFixture({ turn: 0 });
+    const { client, updateCombat } = buildStaleCacheClient(combat);
+
+    await handleSetInitiative({ combatantId: ALICE, initiative: 1 }, client);
+
+    expect(updateCombat).toHaveBeenCalledWith(COMBAT_ID, { turn: 2 });
+    expect(combat.combatants.find((c) => c._id === ALICE)?.initiative).toBe(18);
+  });
+
+  it('reports the still-acting combatant in the tool output', async () => {
+    const combat = makeCombatFixture({ turn: 0 });
+    const { client } = buildStaleCacheClient(combat);
+
+    const text = (await handleSetInitiative({ combatantId: ALICE, initiative: 1 }, client))
+      .content[0].text;
+
+    expect(text).toContain('**Initiative Set**');
+    expect(text).toContain('Alice');
+    expect(text).toContain('turn 3 of 3');
+  });
+
+  it('leaves `turn` alone when the acting combatant keeps its index', async () => {
+    // Alice is acting at index 0 and stays on top (18 -> 17 still beats 12).
+    const combat = makeCombatFixture({ turn: 0 });
+    const { client, updateCombat } = buildStaleCacheClient(combat);
+
+    await handleSetInitiative({ combatantId: ALICE, initiative: 17 }, client);
+
+    expect(updateCombat).not.toHaveBeenCalled();
+  });
+
+  it('leaves `turn` alone when no combatant is acting yet (turn null)', async () => {
+    const combat = makeCombatFixture({ turn: null });
+    const { client, updateCombat, setCombatantInitiative } = buildStaleCacheClient(combat);
+
+    await handleSetInitiative({ combatantId: ALICE, initiative: 1 }, client);
+
+    expect(setCombatantInitiative).toHaveBeenCalledWith(COMBAT_ID, ALICE, 1);
+    expect(updateCombat).not.toHaveBeenCalled();
+  });
+
+  it('leaves `turn` alone before the encounter has started (round 0)', async () => {
+    // Pre-roll setup: initiatives get assigned before anyone is acting.
+    const combat = makeCombatFixture({ round: 0, turn: 0, started: false });
+    const { client, updateCombat } = buildStaleCacheClient(combat);
+
+    await handleSetInitiative({ combatantId: ALICE, initiative: 1 }, client);
+
+    expect(updateCombat).not.toHaveBeenCalled();
+  });
+
+  it('leaves `turn` alone when the stored index resolves to no combatant', async () => {
+    const combat = makeCombatFixture({ turn: 9 });
+    const { client, updateCombat, setCombatantInitiative } = buildStaleCacheClient(combat);
+
+    await expect(
+      handleSetInitiative({ combatantId: ALICE, initiative: 1 }, client),
+    ).resolves.toBeDefined();
+
+    expect(setCombatantInitiative).toHaveBeenCalledWith(COMBAT_ID, ALICE, 1);
+    expect(updateCombat).not.toHaveBeenCalled();
+  });
+
+  it('still writes the initiative when the target combatant is unknown to the cache', async () => {
+    const combat = makeCombatFixture({ turn: 0 });
+    const { client, updateCombat, setCombatantInitiative } = buildStaleCacheClient(combat);
+
+    await handleSetInitiative({ combatantId: 'ffffffffffffffff', initiative: 30 }, client);
+
+    expect(setCombatantInitiative).toHaveBeenCalledWith(COMBAT_ID, 'ffffffffffffffff', 30);
+    expect(updateCombat).not.toHaveBeenCalled();
+  });
+
+  it('does not re-anchor a combat other than the active one', async () => {
+    // Only the active combat is readable from the cache, so an explicit
+    // `combatId` for some other encounter has no turn order to recompute.
+    const combat = makeCombatFixture({ turn: 0 });
+    const { client, updateCombat, setCombatantInitiative } = buildStaleCacheClient(combat);
+    const otherCombatId = 'ffffffffffff0000';
+
+    await handleSetInitiative(
+      { combatantId: ALICE, initiative: 1, combatId: otherCombatId },
+      client,
+    );
+
+    expect(setCombatantInitiative).toHaveBeenCalledWith(otherCombatId, ALICE, 1);
+    expect(updateCombat).not.toHaveBeenCalled();
+  });
+
+  it('re-anchors when the active combat is named explicitly', async () => {
+    const combat = makeCombatFixture({ turn: 0 });
+    const { client, updateCombat } = buildStaleCacheClient(combat);
+
+    await handleSetInitiative({ combatantId: ALICE, initiative: 1, combatId: COMBAT_ID }, client);
+
+    expect(updateCombat).toHaveBeenCalledWith(COMBAT_ID, { turn: 2 });
   });
 });

--- a/src/tools/handlers/__tests__/combat-mutations.test.ts
+++ b/src/tools/handlers/__tests__/combat-mutations.test.ts
@@ -2,6 +2,7 @@ import { McpError } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it, vi } from 'vitest';
 import { FoundryClient } from '../../../foundry/client.js';
 import type { WorldCombat } from '../../../foundry/types.js';
+import { handleGetCombatState } from '../combat.js';
 import {
   computeNextTurn,
   handleEndCombat,
@@ -9,6 +10,7 @@ import {
   handleSetInitiative,
   handleStartCombat,
 } from '../combat-mutations.js';
+import { getTurnOrder } from '../combat-order.js';
 
 const COMBAT_ID = 'cccccccccccccccc'; // 16 alphanumeric chars
 const COMBATANT_ID = 'dddddddddddddddd';
@@ -498,5 +500,176 @@ describe('FoundryClient combat mutations', () => {
     await expect(
       client.setCombatantInitiative(COMBAT_ID, COMBATANT_ID, Number.POSITIVE_INFINITY),
     ).rejects.toThrow(/Invalid initiative/);
+  });
+});
+
+// --------------------------------------------------------------------------
+// #214: `Combat#turn` indexes the INITIATIVE-sorted turn order, not the stored
+// (creation) order of `combat.combatants`. The read tool (get_combat_state) and
+// the write tool (next_turn) must agree on that ordering.
+// --------------------------------------------------------------------------
+describe('initiative-ordered turn semantics (#214)', () => {
+  /**
+   * Stored (creation) order deliberately differs from initiative order:
+   *   stored:   Bob (5), Alice (18), Charlie (12)
+   *   initiative order: Alice (18), Charlie (12), Bob (5)
+   */
+  const makeUnsortedCombat = (overrides: Partial<WorldCombat> = {}): WorldCombat =>
+    makeCombat({
+      turn: 0,
+      round: 1,
+      combatants: [
+        { _id: 'bobbobbobbobbobb', name: 'Bob', initiative: 5, hidden: false, defeated: false },
+        { _id: 'alicealicealice1', name: 'Alice', initiative: 18, hidden: false, defeated: false },
+        {
+          _id: 'charliecharlie11',
+          name: 'Charlie',
+          initiative: 12,
+          hidden: false,
+          defeated: false,
+        },
+      ],
+      ...overrides,
+    });
+
+  const readCurrentName = async (combat: WorldCombat): Promise<string> => {
+    const client = {
+      getCombatState: vi.fn().mockReturnValue(combat),
+      getRawActor: vi.fn().mockReturnValue(undefined),
+    } as unknown as FoundryClient;
+    const text = (await handleGetCombatState({}, client)).content[0]?.text ?? '';
+    const line = text.split('\n').find((l) => l.includes('<-- CURRENT')) ?? '';
+    return /\*\*(.+?)\*\*/.exec(line)?.[1] ?? '';
+  };
+
+  describe('getTurnOrder', () => {
+    it('sorts by initiative descending without mutating the source array', () => {
+      const combat = makeUnsortedCombat();
+      const stored = combat.combatants.map((c) => c.name);
+
+      expect(getTurnOrder(combat).map((c) => c.name)).toEqual(['Alice', 'Charlie', 'Bob']);
+      expect(combat.combatants.map((c) => c.name)).toEqual(stored);
+    });
+
+    it('places un-rolled (null) initiative last and breaks ties by document id', () => {
+      const combat = makeCombat({
+        combatants: [
+          {
+            _id: 'zzzzzzzzzzzzzzzz',
+            name: 'Zed',
+            initiative: null,
+            hidden: false,
+            defeated: false,
+          },
+          {
+            _id: 'aaaaaaaaaaaaaaaa',
+            name: 'Ann',
+            initiative: null,
+            hidden: false,
+            defeated: false,
+          },
+          { _id: 'mmmmmmmmmmmmmmmm', name: 'Mia', initiative: 7, hidden: false, defeated: false },
+          { _id: 'bbbbbbbbbbbbbbbb', name: 'Ben', initiative: 7, hidden: false, defeated: false },
+        ],
+      });
+
+      expect(getTurnOrder(combat).map((c) => c.name)).toEqual(['Ben', 'Mia', 'Ann', 'Zed']);
+    });
+  });
+
+  it('computeNextTurn indexes the initiative order, not the stored order', () => {
+    const combat = makeUnsortedCombat({ turn: 0 });
+    // turn 0 is Alice (18); the next turn is Charlie (12) at sorted index 1.
+    const next = computeNextTurn(combat);
+    expect(next).toEqual({ turn: 1, round: 1 });
+    expect(getTurnOrder(combat)[next.turn]?.name).toBe('Charlie');
+  });
+
+  it('computeNextTurn evaluates skipDefeated against the initiative order', () => {
+    // Alice (18, DEFEATED) is the current turn; the next live combatant is
+    // Charlie at sorted index 1. Indexing stored order would test Alice's
+    // `defeated` flag at index 1 and wrongly skip to index 2 (Charlie's slot
+    // in stored order is 2, but the current combatant there is Bob).
+    const combat = makeUnsortedCombat({ turn: 0 });
+    const alice = combat.combatants.find((c) => c.name === 'Alice');
+    if (!alice) {
+      throw new Error('fixture missing Alice');
+    }
+    alice.defeated = true;
+
+    const next = computeNextTurn(combat, true);
+    expect(next).toEqual({ turn: 1, round: 1 });
+    expect(getTurnOrder(combat)[next.turn]?.name).toBe('Charlie');
+  });
+
+  it('computeNextTurn wraps to the first live combatant in initiative order', () => {
+    // Stored order: Bob (5), Alice (18, defeated), Charlie (12).
+    // Initiative order: Alice (defeated), Charlie, Bob -> first alive is Charlie (1).
+    const combat = makeUnsortedCombat({ turn: 2 });
+    const alice = combat.combatants.find((c) => c.name === 'Alice');
+    if (!alice) {
+      throw new Error('fixture missing Alice');
+    }
+    alice.defeated = true;
+
+    const next = computeNextTurn(combat, true);
+    expect(next).toEqual({ turn: 1, round: 2 });
+    expect(getTurnOrder(combat)[next.turn]?.name).toBe('Charlie');
+  });
+
+  it('next_turn names the same combatant get_combat_state marks as CURRENT', async () => {
+    const combat = makeUnsortedCombat({ turn: 0 });
+    const updateCombat = vi.fn();
+    const client = {
+      getCombatState: vi.fn().mockReturnValue(combat),
+      updateCombat,
+    } as unknown as FoundryClient;
+
+    const text = (await handleNextTurn({}, client)).content[0].text;
+
+    // Alice (18) -> Charlie (12), NOT Alice (stored index 1).
+    expect(text).toContain('**Now acting:** Charlie');
+    expect(updateCombat).toHaveBeenCalledWith(COMBAT_ID, { turn: 1, round: 1 });
+
+    // The cache then receives the write; the read tool must agree.
+    combat.turn = 1;
+    expect(await readCurrentName(combat)).toBe('Charlie');
+  });
+
+  it('stays consistent after set_initiative reshuffles the turn order', async () => {
+    const combat = makeUnsortedCombat({ turn: 0 });
+    const alice = combat.combatants.find((c) => c.name === 'Alice');
+    if (!alice) {
+      throw new Error('fixture missing Alice');
+    }
+
+    // Before: order is Alice (18), Charlie (12), Bob (5) — turn 0 is Alice.
+    expect(await readCurrentName(combat)).toBe('Alice');
+
+    const setCombatantInitiative = vi.fn(() => {
+      // Mirror the cache broadcast: Alice drops to the bottom of the order.
+      alice.initiative = 1;
+    });
+    const updateCombat = vi.fn();
+    const client = {
+      getCombatState: vi.fn().mockReturnValue(combat),
+      setCombatantInitiative,
+      updateCombat,
+    } as unknown as FoundryClient;
+
+    await handleSetInitiative({ combatantId: alice._id, initiative: 1 }, client);
+    expect(setCombatantInitiative).toHaveBeenCalledWith(COMBAT_ID, alice._id, 1);
+
+    // Order is now Charlie (12), Bob (5), Alice (1) — turn 0 is Charlie, and
+    // stored order (Bob, Alice, Charlie) still disagrees with it.
+    expect(getTurnOrder(combat).map((c) => c.name)).toEqual(['Charlie', 'Bob', 'Alice']);
+    expect(await readCurrentName(combat)).toBe('Charlie');
+
+    const text = (await handleNextTurn({}, client)).content[0].text;
+    expect(text).toContain('**Now acting:** Bob');
+    expect(updateCombat).toHaveBeenCalledWith(COMBAT_ID, { turn: 1, round: 1 });
+
+    combat.turn = 1;
+    expect(await readCurrentName(combat)).toBe('Bob');
   });
 });

--- a/src/tools/handlers/__tests__/combat-mutations.test.ts
+++ b/src/tools/handlers/__tests__/combat-mutations.test.ts
@@ -691,13 +691,21 @@ describe('set_initiative re-anchors Combat#turn', () => {
   const BOB = 'bobbobbobbobbobb';
   const CHARLIE = 'charliecharlie11';
 
-  /** stored: Bob (5), Alice (18), Charlie (12) — initiative: Alice, Charlie, Bob. */
+  /**
+   * stored: Bob (5), Alice (18), Charlie (12) — initiative: Alice, Charlie, Bob.
+   *
+   * Deliberately shaped the way FoundryVTT actually persists a Combat: there is
+   * **no `started` field**. `Combat#started` is a client-side getter
+   * (`turns.length > 0 && round > 0`); `BaseCombat.defineSchema()` never
+   * declares it, so no document arriving over the `world` socket payload — nor
+   * any `modifyDocument` broadcast — carries one. A fixture that invents
+   * `started: true` hides a re-anchor that is dead against every real world.
+   */
   const makeCombatFixture = (overrides: Partial<WorldCombat> = {}): WorldCombat => ({
     _id: COMBAT_ID,
     active: true,
     round: 1,
     turn: 0,
-    started: true,
     combatants: [
       { _id: BOB, name: 'Bob', initiative: 5, hidden: false, defeated: false },
       { _id: ALICE, name: 'Alice', initiative: 18, hidden: false, defeated: false },
@@ -718,6 +726,30 @@ describe('set_initiative re-anchors Combat#turn', () => {
     } as unknown as FoundryClient;
     return { client, updateCombat, setCombatantInitiative };
   };
+
+  it('re-anchors on a document with no `started` field, as FoundryVTT persists it', async () => {
+    // The regression guard for the whole describe block: `started` is not part
+    // of the persisted Combat schema, so reading it gates the re-anchor off on
+    // every real world while fabricated fixtures stay green.
+    const combat = makeCombatFixture({ turn: 0 });
+    expect('started' in combat).toBe(false);
+
+    const { client, updateCombat } = buildStaleCacheClient(combat);
+
+    await handleSetInitiative({ combatantId: ALICE, initiative: 1 }, client);
+
+    expect(updateCombat).toHaveBeenCalledWith(COMBAT_ID, { turn: 2 });
+  });
+
+  it('leaves `turn` alone when the combat has no combatants', async () => {
+    // Derived started-ness needs a turn order to point into.
+    const combat = makeCombatFixture({ turn: 0, combatants: [] });
+    const { client, updateCombat } = buildStaleCacheClient(combat);
+
+    await handleSetInitiative({ combatantId: ALICE, initiative: 1 }, client);
+
+    expect(updateCombat).not.toHaveBeenCalled();
+  });
 
   it('follows the acting combatant when another combatant slides under the stored turn', async () => {
     // Charlie is acting (initiative index 1). Bob jumps to 20 -> order becomes
@@ -776,7 +808,8 @@ describe('set_initiative re-anchors Combat#turn', () => {
 
   it('leaves `turn` alone before the encounter has started (round 0)', async () => {
     // Pre-roll setup: initiatives get assigned before anyone is acting.
-    const combat = makeCombatFixture({ round: 0, turn: 0, started: false });
+    // Started-ness is derived from `round`, exactly as core derives it.
+    const combat = makeCombatFixture({ round: 0, turn: 0 });
     const { client, updateCombat } = buildStaleCacheClient(combat);
 
     await handleSetInitiative({ combatantId: ALICE, initiative: 1 }, client);

--- a/src/tools/handlers/__tests__/combat.test.ts
+++ b/src/tools/handlers/__tests__/combat.test.ts
@@ -176,3 +176,63 @@ describe('handleGetCombatState', () => {
     expect(text).toContain('Round 2');
   });
 });
+
+describe('handleGetCombatState — turn order (#214)', () => {
+  const makeClient = (combat: WorldCombat) =>
+    ({
+      getCombatState: vi.fn().mockReturnValue(combat),
+      getRawActor: vi.fn().mockReturnValue(undefined),
+    }) as unknown as FoundryClient;
+
+  it('does not reorder the cached combatants array (a read must not mutate the cache)', async () => {
+    const combat = buildCombat({
+      turn: 0,
+      combatants: [
+        buildCombatant({ _id: 'c-bob', name: 'Bob', initiative: 5 }),
+        buildCombatant({ _id: 'c-alice', name: 'Alice', initiative: 18 }),
+        buildCombatant({ _id: 'c-charlie', name: 'Charlie', initiative: 12 }),
+      ],
+    });
+    const storedOrder = combat.combatants.map((c) => c.name);
+
+    await handleGetCombatState({}, makeClient(combat));
+
+    expect(combat.combatants.map((c) => c.name)).toEqual(storedOrder);
+  });
+
+  it('marks the combatant at combat.turn in INITIATIVE order as CURRENT', async () => {
+    // Stored (creation) order deliberately differs from initiative order.
+    const combat = buildCombat({
+      turn: 1,
+      combatants: [
+        buildCombatant({ _id: 'c-bob', name: 'Bob', initiative: 5 }),
+        buildCombatant({ _id: 'c-alice', name: 'Alice', initiative: 18 }),
+        buildCombatant({ _id: 'c-charlie', name: 'Charlie', initiative: 12 }),
+      ],
+    });
+
+    const text = getText(await handleGetCombatState({}, makeClient(combat)));
+
+    // Sorted order is Alice (18), Charlie (12), Bob (5) -> turn 1 is Charlie.
+    expect(text).toMatch(/2\. \[12\] \*\*Charlie\*\*.*<-- CURRENT/);
+    expect(text).not.toMatch(/\*\*Alice\*\*.*<-- CURRENT/);
+    expect(text).not.toMatch(/\*\*Bob\*\*.*<-- CURRENT/);
+  });
+
+  it('orders un-rolled (null) initiative last, breaking ties by document id', async () => {
+    const combat = buildCombat({
+      turn: 0,
+      combatants: [
+        buildCombatant({ _id: 'c-zed', name: 'Zed', initiative: null }),
+        buildCombatant({ _id: 'c-ann', name: 'Ann', initiative: null }),
+        buildCombatant({ _id: 'c-rex', name: 'Rex', initiative: 3 }),
+      ],
+    });
+
+    const text = getText(await handleGetCombatState({}, makeClient(combat)));
+
+    expect(text).toContain('1. [3] **Rex**');
+    expect(text).toContain('2. [?] **Ann**');
+    expect(text).toContain('3. [?] **Zed**');
+  });
+});

--- a/src/tools/handlers/__tests__/diagnostics.test.ts
+++ b/src/tools/handlers/__tests__/diagnostics.test.ts
@@ -1,11 +1,18 @@
 /**
- * @fileoverview Unit tests for diagnostics handler — get_recent_logs filtering
+ * @fileoverview Unit tests for diagnostics handlers — get_recent_logs
+ * filtering plus the get_system_health / get_health_status reports.
  */
 
 import { describe, expect, it, vi } from 'vitest';
 import type { DiagnosticsClient } from '../../../diagnostics/client.js';
-import type { LogEntry } from '../../../diagnostics/types.js';
-import { handleGetRecentLogs } from '../diagnostics.js';
+import type { LogEntry, SystemHealth } from '../../../diagnostics/types.js';
+import { SystemHealthSchema } from '../../../diagnostics/types.js';
+import type { FoundryClient } from '../../../foundry/client.js';
+import {
+  handleGetHealthStatus,
+  handleGetRecentLogs,
+  handleGetSystemHealth,
+} from '../diagnostics.js';
 
 // Minimal LogEntry factory
 function makeEntry(
@@ -202,5 +209,191 @@ describe('handleGetRecentLogs', () => {
         (result as { content: Array<{ type: string; text: string }> }).content[0]?.text ?? '';
       expect(text).toContain('No log entries found.');
     });
+  });
+});
+
+// ============================================================================
+// System health handlers (#216)
+//
+// `SystemHealthSchema.parse()` strips unknown keys, so the fixtures below are
+// deliberately run through the real schema: anything the handlers read must be
+// a field the schema actually declares, or it will be `undefined` here just as
+// it is in production.
+// ============================================================================
+
+function makeHealth(overrides: Record<string, unknown> = {}): SystemHealth {
+  return SystemHealthSchema.parse({
+    timestamp: '2024-06-01T12:00:00.000Z',
+    server: {
+      foundryVersion: '12.331',
+      systemVersion: 'dnd5e 3.3.1',
+      worldId: 'test-world',
+      uptime: 7320, // 2h 2m
+    },
+    users: { total: 5, active: 3, gm: 1 },
+    modules: { total: 50, active: 35 },
+    performance: {
+      memory: {
+        rss: 209_715_200, // 200 MB
+        heapTotal: 67_108_864, // 64 MB
+        heapUsed: 47_185_920, // 45 MB
+        external: 1_048_576,
+        arrayBuffers: 524_288,
+      },
+      connectedClients: 3,
+    },
+    logs: { bufferSize: 500, recentErrors: 2, recentWarnings: 5, errorRate: 0.1 },
+    status: 'healthy',
+    ...overrides,
+  });
+}
+
+function healthClient(health: SystemHealth): DiagnosticsClient {
+  return {
+    getSystemHealth: vi.fn().mockResolvedValue(health),
+  } as unknown as DiagnosticsClient;
+}
+
+function getText(result: { content: Array<{ type: string; text: string }> }): string {
+  return result.content[0]?.text ?? '';
+}
+
+describe('handleGetSystemHealth', () => {
+  it('renders the nested values the schema actually defines', async () => {
+    const text = getText(await handleGetSystemHealth({}, healthClient(makeHealth())));
+
+    expect(text).toContain('**Overall Status:** healthy');
+    expect(text).toContain('**Reported At:** 2024-06-01T12:00:00.000Z');
+    // server.*
+    expect(text).toContain('12.331');
+    expect(text).toContain('dnd5e 3.3.1');
+    expect(text).toContain('test-world');
+    expect(text).toContain('**Uptime:** 2h 2m');
+    // users.* / modules.*
+    expect(text).toContain('3 active / 5 total');
+    expect(text).toContain('1 GM');
+    expect(text).toContain('35 active / 50 installed');
+    // performance.*
+    expect(text).toContain('**Connected Clients:** 3');
+    expect(text).toContain('45 MB used / 64 MB total');
+    expect(text).toContain('200 MB');
+    // logs.*
+    expect(text).toContain('**Recent Errors:** 2');
+    expect(text).toContain('**Recent Warnings:** 5');
+    expect(text).toContain('**Buffer:** 500 entries');
+    expect(text).toContain('**Error Rate:** 0.1%');
+  });
+
+  it('renders no "N/A" placeholders for a fully populated payload', async () => {
+    const text = getText(await handleGetSystemHealth({}, healthClient(makeHealth())));
+    expect(text).not.toContain('N/A');
+  });
+
+  it('drops metrics the diagnostics schema has no field for', async () => {
+    const text = getText(await handleGetSystemHealth({}, healthClient(makeHealth())));
+
+    // No CPU/disk/throughput/response-time field exists anywhere in SystemHealthSchema
+    expect(text).not.toMatch(/CPU/i);
+    expect(text).not.toMatch(/Disk/i);
+    expect(text).not.toMatch(/Throughput/i);
+    expect(text).not.toMatch(/Response Time/i);
+  });
+
+  it('omits optional server uptime rather than printing a placeholder', async () => {
+    const health = makeHealth({
+      server: { foundryVersion: '12.331', systemVersion: 'dnd5e 3.3.1', worldId: 'test-world' },
+    });
+
+    const text = getText(await handleGetSystemHealth({}, healthClient(health)));
+
+    expect(text).not.toContain('**Uptime:**');
+    expect(text).not.toContain('N/A');
+    expect(text).toContain('**Overall Status:** healthy');
+  });
+
+  it('omits memory lines when performance.memory is absent', async () => {
+    const health = makeHealth({ performance: { connectedClients: 7 } });
+
+    const text = getText(await handleGetSystemHealth({}, healthClient(health)));
+
+    expect(text).toContain('**Connected Clients:** 7');
+    expect(text).not.toContain('MB');
+    expect(text).not.toContain('N/A');
+  });
+
+  it('reports a critical status verbatim', async () => {
+    const text = getText(
+      await handleGetSystemHealth({}, healthClient(makeHealth({ status: 'critical' }))),
+    );
+    expect(text).toContain('**Overall Status:** critical');
+  });
+});
+
+describe('handleGetHealthStatus', () => {
+  function worldClient(connected: boolean): FoundryClient {
+    return {
+      isConnected: () => connected,
+      getWorldInfo: vi.fn().mockResolvedValue({
+        id: 'test-world',
+        title: 'Test World',
+        description: '',
+        system: 'dnd5e',
+        coreVersion: '12.331',
+        systemVersion: '3.3.1',
+        playtime: 0,
+        created: '2024-01-01T00:00:00.000Z',
+        modified: '2024-06-01T00:00:00.000Z',
+      }),
+    } as unknown as FoundryClient;
+  }
+
+  it('renders real world and system-health values, not placeholders', async () => {
+    const text = getText(
+      await handleGetHealthStatus({}, worldClient(true), healthClient(makeHealth())),
+    );
+
+    expect(text).toContain('✅ Connected');
+    expect(text).toContain('**Title:** Test World');
+    expect(text).toContain('**System:** dnd5e');
+    expect(text).toContain('**Core Version:** 12.331');
+    expect(text).toContain('**Status:** healthy');
+    expect(text).toContain('**Uptime:** 2h 2m');
+    expect(text).toContain('3 active / 5 total');
+    expect(text).toContain('45 MB');
+    expect(text).toContain('**Recent Errors:** 2');
+    expect(text).not.toContain('N/A');
+  });
+
+  it('drops the unbacked CPU and playtime lines', async () => {
+    const text = getText(
+      await handleGetHealthStatus({}, worldClient(true), healthClient(makeHealth())),
+    );
+
+    expect(text).not.toMatch(/CPU/i);
+    expect(text).not.toMatch(/Playtime/i);
+  });
+
+  it('degrades gracefully when system health is unavailable', async () => {
+    const failing = {
+      getSystemHealth: vi.fn().mockRejectedValue(new Error('no REST module')),
+    } as unknown as DiagnosticsClient;
+
+    const text = getText(await handleGetHealthStatus({}, worldClient(false), failing));
+
+    expect(text).toContain('❌ Disconnected');
+    expect(text).toContain('**Title:** Test World');
+    expect(text).toContain('ℹ️ Not available');
+  });
+
+  it('degrades gracefully when world info is unavailable', async () => {
+    const failingWorld = {
+      isConnected: () => false,
+      getWorldInfo: vi.fn().mockRejectedValue(new Error('not connected')),
+    } as unknown as FoundryClient;
+
+    const text = getText(await handleGetHealthStatus({}, failingWorld, healthClient(makeHealth())));
+
+    expect(text).toContain('ℹ️ Not available');
+    expect(text).toContain('**Status:** healthy');
   });
 });

--- a/src/tools/handlers/__tests__/diagnostics.test.ts
+++ b/src/tools/handlers/__tests__/diagnostics.test.ts
@@ -330,9 +330,10 @@ describe('handleGetSystemHealth', () => {
 });
 
 describe('handleGetHealthStatus', () => {
-  function worldClient(connected: boolean): FoundryClient {
+  function worldClient(connected: boolean, stale = false): FoundryClient {
     return {
       isConnected: () => connected,
+      isWorldDataStale: () => stale,
       getWorldInfo: vi.fn().mockResolvedValue({
         id: 'test-world',
         title: 'Test World',
@@ -388,6 +389,7 @@ describe('handleGetHealthStatus', () => {
   it('degrades gracefully when world info is unavailable', async () => {
     const failingWorld = {
       isConnected: () => false,
+      isWorldDataStale: () => false,
       getWorldInfo: vi.fn().mockRejectedValue(new Error('not connected')),
     } as unknown as FoundryClient;
 
@@ -395,5 +397,32 @@ describe('handleGetHealthStatus', () => {
 
     expect(text).toContain('ℹ️ Not available');
     expect(text).toContain('**Status:** healthy');
+  });
+
+  /**
+   * #217's second impact bullet: after the socket drops, reads keep being
+   * served from the cache. Rendering that snapshot with no marker presents a
+   * point-in-time copy as though it were live — and after an automatic
+   * reconnect the connection line reads "✅ Connected" again while the cache is
+   * still missing every broadcast from the outage.
+   */
+  it('marks the world section stale when the cache is no longer being kept live', async () => {
+    const text = getText(
+      await handleGetHealthStatus({}, worldClient(true, true), healthClient(makeHealth())),
+    );
+
+    expect(text).toMatch(/stale/i);
+    expect(text).toContain('refresh_world_data');
+    // Still rendered — a flagged answer beats no answer.
+    expect(text).toContain('**Title:** Test World');
+  });
+
+  it('leaves the world section unmarked while the cache is live', async () => {
+    const text = getText(
+      await handleGetHealthStatus({}, worldClient(true), healthClient(makeHealth())),
+    );
+
+    expect(text).not.toMatch(/stale/i);
+    expect(text).not.toContain('refresh_world_data');
   });
 });

--- a/src/tools/handlers/__tests__/resources.test.ts
+++ b/src/tools/handlers/__tests__/resources.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { DiagnosticsClient } from '../../../diagnostics/client.js';
+import type { FoundryClient } from '../../../foundry/client.js';
+import type { WorldCombat } from '../../../foundry/types.js';
+import { handleReadResource } from '../resources.js';
+
+const COMBAT_ID = 'cccccccccccccccc';
+
+/**
+ * Stored (creation) order deliberately differs from initiative order — the
+ * same fixture the #214 combat specs use:
+ *   stored:           Bob (5), Alice (18), Charlie (12)
+ *   initiative order: Alice (18), Charlie (12), Bob (5)
+ */
+const makeUnsortedCombat = (overrides: Partial<WorldCombat> = {}): WorldCombat => ({
+  _id: COMBAT_ID,
+  active: true,
+  round: 1,
+  turn: 0,
+  started: true,
+  combatants: [
+    { _id: 'bobbobbobbobbobb', name: 'Bob', initiative: 5, hidden: false, defeated: false },
+    { _id: 'alicealicealice1', name: 'Alice', initiative: 18, hidden: false, defeated: false },
+    { _id: 'charliecharlie11', name: 'Charlie', initiative: 12, hidden: false, defeated: false },
+  ],
+  ...overrides,
+});
+
+const stubDiagnostics = () =>
+  ({
+    getSystemHealth: vi.fn().mockRejectedValue(new Error('no REST')),
+  }) as unknown as DiagnosticsClient;
+
+/** Reads a resource and parses the single JSON content payload. */
+const readJson = async (uri: string, client: Partial<FoundryClient>) => {
+  const result = await handleReadResource(
+    uri,
+    client as unknown as FoundryClient,
+    stubDiagnostics(),
+  );
+  const text = result.contents[0]?.text ?? '';
+  return JSON.parse(text) as Record<string, unknown>;
+};
+
+// --------------------------------------------------------------------------
+// #214 follow-up: `foundry://combat` is the id-bearing companion to
+// `get_combat_state`, whose ordinals are initiative-ordered. Emitting the raw
+// cached `combatants` array (creation order) next to a `turn` that indexes the
+// initiative order makes `combatants[turn]` — and "the Nth name I just read" —
+// resolve to the WRONG combatant.
+// --------------------------------------------------------------------------
+describe('foundry://combat resource', () => {
+  it('emits combatants in initiative order, matching the ordinals get_combat_state prints', async () => {
+    const combat = makeUnsortedCombat();
+    const payload = await readJson('foundry://combat', {
+      getCombatState: vi.fn().mockReturnValue(combat),
+    });
+
+    const emitted = payload.combat as WorldCombat;
+    expect(emitted.combatants.map((c) => c.name)).toEqual(['Alice', 'Charlie', 'Bob']);
+    // `get_combat_state` prints "3. **Bob**"; combatants[2] must be Bob's id.
+    expect(emitted.combatants[2]?._id).toBe('bobbobbobbobbobb');
+  });
+
+  it('resolves `turn` against the emitted combatants array', async () => {
+    const combat = makeUnsortedCombat({ turn: 1 });
+    const payload = await readJson('foundry://combat', {
+      getCombatState: vi.fn().mockReturnValue(combat),
+    });
+
+    const emitted = payload.combat as WorldCombat;
+    expect(emitted.turn).toBe(1);
+    expect(emitted.combatants[emitted.turn ?? 0]?.name).toBe('Charlie');
+  });
+
+  it('keeps the other Combat document fields intact', async () => {
+    const combat = makeUnsortedCombat();
+    const payload = await readJson('foundry://combat', {
+      getCombatState: vi.fn().mockReturnValue(combat),
+    });
+
+    const emitted = payload.combat as WorldCombat;
+    expect(emitted._id).toBe(COMBAT_ID);
+    expect(emitted.round).toBe(1);
+    expect(emitted.active).toBe(true);
+    expect(emitted.started).toBe(true);
+  });
+
+  it('does not reorder the cached combatants array', async () => {
+    const combat = makeUnsortedCombat();
+    await readJson('foundry://combat', { getCombatState: vi.fn().mockReturnValue(combat) });
+
+    expect(combat.combatants.map((c) => c.name)).toEqual(['Bob', 'Alice', 'Charlie']);
+  });
+
+  it('emits a null combat when no encounter is active', async () => {
+    const payload = await readJson('foundry://combat', {
+      getCombatState: vi.fn().mockReturnValue(null),
+    });
+
+    expect(payload.combat).toBeNull();
+  });
+});

--- a/src/tools/handlers/__tests__/search_logs.test.ts
+++ b/src/tools/handlers/__tests__/search_logs.test.ts
@@ -3,99 +3,209 @@
  *
  * Lives in a separate test file from diagnostics.test.ts to keep
  * the existing get_recent_logs coverage untouched.
+ *
+ * `DiagnosticsClient.searchLogs()` resolves to a `LogSearchResponse` **object**
+ * (`{ logs, matches, pattern, searchTimeframe }`), validated by
+ * `LogSearchResponseSchema`. These tests mock that real shape — never a bare
+ * array — so the handler is exercised against what the client actually returns.
  */
 
 import { describe, expect, it, vi } from 'vitest';
 import type { DiagnosticsClient } from '../../../diagnostics/client.js';
+import type { LogEntry, LogSearchResponse } from '../../../diagnostics/types.js';
+import { LogSearchResponseSchema } from '../../../diagnostics/types.js';
 import { handleSearchLogs } from '../diagnostics.js';
 
 function getText(result: { content: Array<{ type: string; text: string }> }): string {
   return result.content[0]?.text ?? '';
 }
 
-function mockClient(logs: unknown): DiagnosticsClient {
+function makeEntry(
+  level: LogEntry['level'],
+  timestamp: string,
+  message: string,
+  source: LogEntry['source'] = 'foundry',
+): LogEntry {
+  return { timestamp, level, message, source };
+}
+
+/**
+ * Build a mock client whose `searchLogs` resolves to a *schema-validated*
+ * `LogSearchResponse`, so the fixtures cannot drift from the real contract.
+ */
+function mockClient(
+  response: Partial<LogSearchResponse> & { logs: LogEntry[] },
+): DiagnosticsClient {
+  const parsed = LogSearchResponseSchema.parse({
+    logs: response.logs,
+    matches: response.matches ?? response.logs.length,
+    pattern: response.pattern ?? 'pattern',
+    searchTimeframe: response.searchTimeframe ?? 'all',
+  });
+
   return {
-    searchLogs: vi.fn(async (_params: { pattern: string }) => logs),
+    searchLogs: vi.fn().mockResolvedValue(parsed),
   } as unknown as DiagnosticsClient;
 }
 
-describe('handleSearchLogs', () => {
-  describe('happy path', () => {
-    it('formats matching log entries with timestamp, level, and message', async () => {
-      const logs = [
-        {
-          timestamp: '2024-06-01T12:00:00.000Z',
-          level: 'error',
-          message: 'database connection failed',
-        },
-        {
-          timestamp: '2024-06-01T12:00:01.000Z',
-          level: 'warn',
-          message: 'retry attempt 1',
-        },
-      ];
-      const client = mockClient(logs);
+const SAMPLE_ENTRIES: LogEntry[] = [
+  makeEntry('error', '2024-06-01T12:00:00.000Z', 'database connection failed', 'foundry'),
+  makeEntry('warn', '2024-06-01T12:00:01.000Z', 'retry attempt 1', 'module'),
+  makeEntry('info', '2024-06-01T12:00:02.000Z', 'database reconnected', 'foundry'),
+];
 
-      const result = await handleSearchLogs({ query: 'database', level: 'error' }, client);
-      const text = getText(result);
+describe('handleSearchLogs', () => {
+  describe('rendering the response body', () => {
+    it('renders the entries carried in the response object (not a bare array)', async () => {
+      const client = mockClient({ logs: SAMPLE_ENTRIES, matches: 3, pattern: 'database' });
+
+      const text = getText(await handleSearchLogs({ query: 'database' }, client));
 
       expect(text).toContain('Log Search Results');
-      expect(text).toContain('**Query:** "database"');
-      expect(text).toContain('**Level Filter:** error');
-      expect(text).toContain('**Results:** 2');
-      expect(text).toContain('**ERROR** database connection failed');
-      expect(text).toContain('**WARN** retry attempt 1');
-      expect(client.searchLogs).toHaveBeenCalledWith({ pattern: 'database' });
+      expect(text).toContain('[2024-06-01T12:00:00.000Z] **ERROR** database connection failed');
+      expect(text).toContain('[2024-06-01T12:00:01.000Z] **WARN** retry attempt 1');
+      expect(text).toContain('[2024-06-01T12:00:02.000Z] **INFO** database reconnected');
+      expect(text).not.toContain('No logs available');
+      expect(text).not.toContain('No matching log entries found.');
     });
 
-    it('renders default "All levels" filter label when level not supplied', async () => {
-      const client = mockClient([
-        { timestamp: '2024-06-01T12:00:00.000Z', level: 'info', message: 'hello' },
-      ]);
+    it('reports the response `matches` count rather than 0', async () => {
+      const client = mockClient({ logs: SAMPLE_ENTRIES, matches: 42 });
 
-      const result = await handleSearchLogs({ query: 'hello' }, client);
-      const text = getText(result);
+      const text = getText(await handleSearchLogs({ query: 'database' }, client));
 
+      expect(text).toContain('**Matches:** 42');
+      expect(text).toContain('**Showing:** 3');
+    });
+
+    it('echoes the query and the searched timeframe', async () => {
+      const client = mockClient({ logs: SAMPLE_ENTRIES, searchTimeframe: '3600' });
+
+      const text = getText(await handleSearchLogs({ query: 'database' }, client));
+
+      expect(text).toContain('**Query:** "database"');
+      expect(text).toContain('**Timeframe:** 3600');
+    });
+  });
+
+  describe('level parameter', () => {
+    it('forwards a recognized level to searchLogs', async () => {
+      const client = mockClient({ logs: SAMPLE_ENTRIES });
+
+      await handleSearchLogs({ query: 'database', level: 'error' }, client);
+
+      expect(client.searchLogs).toHaveBeenCalledWith({ pattern: 'database', level: 'error' });
+    });
+
+    it('normalizes level casing before forwarding', async () => {
+      const client = mockClient({ logs: SAMPLE_ENTRIES });
+
+      await handleSearchLogs({ query: 'database', level: 'ERROR' }, client);
+
+      expect(client.searchLogs).toHaveBeenCalledWith({ pattern: 'database', level: 'error' });
+    });
+
+    it('omits level from the request when not supplied', async () => {
+      const client = mockClient({ logs: SAMPLE_ENTRIES });
+
+      const text = getText(await handleSearchLogs({ query: 'database' }, client));
+
+      expect(client.searchLogs).toHaveBeenCalledWith({ pattern: 'database' });
       expect(text).toContain('**Level Filter:** All levels');
-      expect(text).toContain('**INFO** hello');
+    });
+
+    it('does not forward an unsupported level and says so in the header', async () => {
+      const client = mockClient({ logs: SAMPLE_ENTRIES });
+
+      // 'debug' is in the tool schema enum but not in the LogEntry level enum
+      const text = getText(await handleSearchLogs({ query: 'database', level: 'debug' }, client));
+
+      expect(client.searchLogs).toHaveBeenCalledWith({ pattern: 'database' });
+      expect(text).toContain('**Level Filter:** debug (unsupported — not applied)');
+    });
+
+    it('reports the applied level in the header', async () => {
+      const client = mockClient({ logs: SAMPLE_ENTRIES });
+
+      const text = getText(await handleSearchLogs({ query: 'database', level: 'warn' }, client));
+
+      expect(text).toContain('**Level Filter:** warn');
+    });
+  });
+
+  describe('limit parameter', () => {
+    it('truncates rendered entries to the requested limit', async () => {
+      const client = mockClient({ logs: SAMPLE_ENTRIES, matches: 3 });
+
+      const text = getText(await handleSearchLogs({ query: 'database', limit: 2 }, client));
+
+      expect(text).toContain('database connection failed');
+      expect(text).toContain('retry attempt 1');
+      expect(text).not.toContain('database reconnected');
+      expect(text).toContain('**Limit:** 2');
+      // total matches is unchanged by the display limit
+      expect(text).toContain('**Matches:** 3');
+      expect(text).toContain('**Showing:** 2');
+    });
+
+    it('defaults to 50 when limit is not supplied', async () => {
+      const client = mockClient({ logs: SAMPLE_ENTRIES });
+
+      const text = getText(await handleSearchLogs({ query: 'database' }, client));
+
+      expect(text).toContain('**Limit:** 50');
+      expect(text).toContain('**Showing:** 3');
+    });
+
+    it('clamps a non-positive limit to 1', async () => {
+      const client = mockClient({ logs: SAMPLE_ENTRIES });
+
+      const text = getText(await handleSearchLogs({ query: 'database', limit: 0 }, client));
+
+      expect(text).toContain('**Limit:** 1');
+      expect(text).toContain('**Showing:** 1');
+      expect(text).not.toContain('retry attempt 1');
+    });
+
+    it('clamps an oversized limit to the hard cap of 1000', async () => {
+      const client = mockClient({ logs: SAMPLE_ENTRIES });
+
+      const text = getText(await handleSearchLogs({ query: 'database', limit: 9999 }, client));
+
+      expect(text).toContain('**Limit:** 1000');
     });
   });
 
   describe('edge cases', () => {
-    it('returns zero results and empty body when client returns empty array', async () => {
-      const client = mockClient([]);
-      const result = await handleSearchLogs({ query: 'xyzzy' }, client);
-      const text = getText(result);
+    it('reports zero results when the response carries no entries', async () => {
+      const client = mockClient({ logs: [], matches: 0 });
 
-      expect(text).toContain('**Results:** 0');
+      const text = getText(await handleSearchLogs({ query: 'xyzzy' }, client));
+
+      expect(text).toContain('**Matches:** 0');
       expect(text).toContain('No matching log entries found.');
     });
 
     it('throws McpError when query is empty string', async () => {
-      const client = mockClient([]);
+      const client = mockClient({ logs: [] });
       await expect(handleSearchLogs({ query: '' } as { query: string }, client)).rejects.toThrow(
         /Query is required/,
       );
     });
 
     it('throws McpError when query is not a string', async () => {
-      const client = mockClient([]);
+      const client = mockClient({ logs: [] });
       await expect(
         handleSearchLogs({ query: 42 } as unknown as { query: string }, client),
       ).rejects.toThrow(/Query is required/);
     });
 
-    it('falls back to defaults when log entries lack timestamp/level/message', async () => {
-      // Use stringifiable values for the fall-through `String(log)` branch
-      const logs = [{}, { message: 'partial' }];
-      const client = mockClient(logs);
+    it('surfaces client failures as a tool error', async () => {
+      const client = {
+        searchLogs: vi.fn().mockRejectedValue(new Error('Failed to search logs: boom')),
+      } as unknown as DiagnosticsClient;
 
-      const result = await handleSearchLogs({ query: 'anything' }, client);
-      const text = getText(result);
-
-      // Entries with no `level` should default to INFO; entries without timestamp get a fresh one
-      expect(text).toContain('**INFO**');
-      expect(text).toContain('**Results:** 2');
+      await expect(handleSearchLogs({ query: 'boom' }, client)).rejects.toThrow(/search logs/);
     });
   });
 });

--- a/src/tools/handlers/combat-mutations.ts
+++ b/src/tools/handlers/combat-mutations.ts
@@ -11,6 +11,7 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { FoundryClient } from '../../foundry/client.js';
 import type { WorldCombat, WorldScene } from '../../foundry/types.js';
+import { getTurnOrder } from './combat-order.js';
 import { withToolError } from './utils.js';
 
 /** A combatant seed derived from a scene token, sent to the create wire. */
@@ -26,6 +27,10 @@ interface CombatantSeed {
  * Advances to the next combatant in order; wrapping past the last combatant
  * rolls over to turn 0 of the next round.
  *
+ * `Combat#turn` is an index into the **initiative-sorted** turn order (see
+ * `combat-order.ts`), *not* into the stored/creation order of
+ * `combat.combatants` — the same order `get_combat_state` renders (#214).
+ *
  * When `skipDefeated` is true, `defeated` combatants are skipped — mirroring
  * Foundry's `Combat#nextTurn`/`nextRound` with the `skipDefeated` setting. If
  * every combatant is defeated, the round still advances (turn 0), matching
@@ -37,7 +42,7 @@ export function computeNextTurn(
   combat: WorldCombat,
   skipDefeated = false,
 ): { turn: number; round: number } {
-  const combatants = combat.combatants;
+  const combatants = getTurnOrder(combat);
   const n = combatants.length;
   if (n === 0) {
     throw new Error('Cannot advance turn: active combat has no combatants');
@@ -84,7 +89,7 @@ export async function handleNextTurn(
     const { turn, round } = computeNextTurn(combat, skipDefeated);
     await foundryClient.updateCombat(combat._id, { turn, round });
 
-    const current = combat.combatants[turn];
+    const current = getTurnOrder(combat)[turn];
     const currentName = current ? current.name : 'unknown';
 
     return {

--- a/src/tools/handlers/combat-mutations.ts
+++ b/src/tools/handlers/combat-mutations.ts
@@ -11,7 +11,11 @@
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { FoundryClient } from '../../foundry/client.js';
 import type { WorldCombat, WorldScene } from '../../foundry/types.js';
-import { getTurnOrder } from './combat-order.js';
+import {
+  getCurrentCombatant,
+  getTurnOrder,
+  turnIndexAfterInitiativeChange,
+} from './combat-order.js';
 import { withToolError } from './utils.js';
 
 /** A combatant seed derived from a scene token, sent to the create wire. */
@@ -138,6 +142,16 @@ The active combat encounter has been removed.`,
  * Sets a combatant's initiative in the active combat (FR-018).
  *
  * `combatId` defaults to the active combat when omitted.
+ *
+ * Writing an initiative re-sorts the turn order underneath the stored
+ * `Combat#turn`, which indexes that order (#214) — so a different combatant can
+ * slide under the stored index. FoundryVTT's `Combat#setupTurns` re-finds the
+ * combatant that was acting and re-points `turn` at its new index; this handler
+ * mirrors that, so the MCP and Foundry never disagree about whose turn it is
+ * after an initiative correction. The re-anchor is skipped when there is
+ * nothing to anchor: no combatant is acting yet (round-0 setup, `turn` null, or
+ * a stale index), the acting combatant's index is unchanged, or the write
+ * targets a combat other than the active one (the only one readable here).
  */
 export async function handleSetInitiative(
   args: { combatantId: string; initiative: number; combatId?: string },
@@ -155,7 +169,8 @@ export async function handleSetInitiative(
     );
   }
 
-  const resolvedCombatId = combatId ?? foundryClient.getCombatState()?._id;
+  const activeCombat = foundryClient.getCombatState();
+  const resolvedCombatId = combatId ?? activeCombat?._id;
   if (!resolvedCombatId) {
     throw new McpError(
       ErrorCode.InvalidRequest,
@@ -163,8 +178,23 @@ export async function handleSetInitiative(
     );
   }
 
+  // Only the active combat is readable from the world-data cache, so only its
+  // turn order can be recomputed. Capture who is acting BEFORE the write.
+  const combat = activeCombat?._id === resolvedCombatId ? activeCombat : undefined;
+  const acting = combat ? getCurrentCombatant(combat) : undefined;
+
   return withToolError('set combatant initiative', async () => {
     await foundryClient.setCombatantInitiative(resolvedCombatId, combatantId, initiative);
+
+    let reanchored = '';
+    if (combat && acting) {
+      const turn = turnIndexAfterInitiativeChange(combat, { combatantId, initiative }, acting._id);
+      if (turn !== undefined && turn !== combat.turn) {
+        await foundryClient.updateCombat(resolvedCombatId, { turn });
+        reanchored = `
+**Still acting:** ${acting.name} (turn ${turn + 1} of ${combat.combatants.length})`;
+      }
+    }
 
     return {
       content: [
@@ -173,7 +203,7 @@ export async function handleSetInitiative(
           text: `⚔️ **Initiative Set**
 **Combat:** ${resolvedCombatId}
 **Combatant:** ${combatantId}
-**Initiative:** ${initiative}`,
+**Initiative:** ${initiative}${reanchored}`,
         },
       ],
     };

--- a/src/tools/handlers/combat-order.ts
+++ b/src/tools/handlers/combat-order.ts
@@ -55,6 +55,20 @@ export function getTurnOrder(combat: WorldCombat): WorldCombatant[] {
 }
 
 /**
+ * Whether the encounter is under way, derived the way core derives it.
+ *
+ * `Combat#started` is a **client-side getter** (`turns.length > 0 && round >
+ * 0`), not schema data: `BaseCombat.defineSchema()` does not declare it, so a
+ * Combat document read out of `worldData` never carries the key. Reading
+ * `combat.started` therefore evaluates to `undefined` on every real world —
+ * only hand-written fixtures have it — so started-ness is computed here from
+ * the two fields the transport does deliver.
+ */
+export function isCombatStarted(combat: WorldCombat): boolean {
+  return combat.round > 0 && combat.combatants.length > 0;
+}
+
+/**
  * Returns the combatant `combat.turn` currently points at, if any.
  *
  * Yields `undefined` when nobody is acting yet — the encounter has not been
@@ -62,7 +76,7 @@ export function getTurnOrder(combat: WorldCombat): WorldCombatant[] {
  * null, or the stored index no longer resolves to a combatant.
  */
 export function getCurrentCombatant(combat: WorldCombat): WorldCombatant | undefined {
-  if (!combat.started || combat.turn === null || combat.turn === undefined) {
+  if (!isCombatStarted(combat) || combat.turn === null || combat.turn === undefined) {
     return undefined;
   }
   return getTurnOrder(combat)[combat.turn];

--- a/src/tools/handlers/combat-order.ts
+++ b/src/tools/handlers/combat-order.ts
@@ -53,3 +53,44 @@ export function compareCombatants(a: WorldCombatant, b: WorldCombatant): number 
 export function getTurnOrder(combat: WorldCombat): WorldCombatant[] {
   return [...combat.combatants].sort(compareCombatants);
 }
+
+/**
+ * Returns the combatant `combat.turn` currently points at, if any.
+ *
+ * Yields `undefined` when nobody is acting yet — the encounter has not been
+ * started (initiatives are commonly assigned during round 0 setup), `turn` is
+ * null, or the stored index no longer resolves to a combatant.
+ */
+export function getCurrentCombatant(combat: WorldCombat): WorldCombatant | undefined {
+  if (!combat.started || combat.turn === null || combat.turn === undefined) {
+    return undefined;
+  }
+  return getTurnOrder(combat)[combat.turn];
+}
+
+/**
+ * Computes where `actingCombatantId` lands in the turn order once `change` is
+ * applied — i.e. the `turn` index that keeps the same combatant acting.
+ *
+ * The change is projected onto a copy rather than read back from the cache:
+ * `setCombatantInitiative` resolves on the `modifyDocument` ack, while the
+ * cache is updated by the separate broadcast, so the cached initiative may or
+ * may not have caught up by the time this runs. Projecting is correct either
+ * way (re-applying the same value is a no-op).
+ *
+ * @returns the new index, or `undefined` if the acting combatant is gone.
+ */
+export function turnIndexAfterInitiativeChange(
+  combat: WorldCombat,
+  change: { combatantId: string; initiative: number },
+  actingCombatantId: string,
+): number | undefined {
+  const projected: WorldCombat = {
+    ...combat,
+    combatants: combat.combatants.map((c) =>
+      c._id === change.combatantId ? { ...c, initiative: change.initiative } : c,
+    ),
+  };
+  const index = getTurnOrder(projected).findIndex((c) => c._id === actingCombatantId);
+  return index === -1 ? undefined : index;
+}

--- a/src/tools/handlers/combat-order.ts
+++ b/src/tools/handlers/combat-order.ts
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Shared combatant turn-order helper (#214).
+ *
+ * FoundryVTT resolves `Combat#turn` against the **initiative-sorted** turn
+ * order, not the stored (creation) order of `Combat#combatants`. Every handler
+ * that maps a `turn` index onto a combatant — the read path
+ * (`get_combat_state`) and the write path (`next_turn`) alike — must therefore
+ * derive that list here, so the two can never drift apart through slightly
+ * different comparators.
+ *
+ * The comparator mirrors core's `Combat._sortCombatants`: initiative
+ * descending, non-numeric (un-rolled) initiative last, ties broken by document
+ * id so the order is deterministic and stable.
+ */
+
+import type { WorldCombat } from '../../foundry/types.js';
+
+/** A single combatant embedded in a `WorldCombat` document. */
+export type WorldCombatant = WorldCombat['combatants'][number];
+
+/** Un-rolled / malformed initiative sorts to the very end of the order. */
+function initiativeOf(c: WorldCombatant): number {
+  return typeof c.initiative === 'number' && Number.isFinite(c.initiative)
+    ? c.initiative
+    : Number.NEGATIVE_INFINITY;
+}
+
+/**
+ * Compares two combatants by Foundry's turn-order rules.
+ *
+ * Initiative descending; combatants without a rolled initiative go last; ties
+ * (including two un-rolled combatants, whose difference is `NaN`) fall back to
+ * the document id so the ordering is total and deterministic.
+ */
+export function compareCombatants(a: WorldCombatant, b: WorldCombatant): number {
+  const byInitiative = initiativeOf(b) - initiativeOf(a);
+  if (byInitiative && !Number.isNaN(byInitiative)) {
+    return byInitiative;
+  }
+  if (a._id === b._id) {
+    return 0;
+  }
+  return a._id > b._id ? 1 : -1;
+}
+
+/**
+ * Returns the combatants of `combat` in turn order.
+ *
+ * Sorts a **copy** — `combat` is a live reference into the world-data cache, so
+ * sorting in place would silently reorder cached state as a side effect of a
+ * read.
+ */
+export function getTurnOrder(combat: WorldCombat): WorldCombatant[] {
+  return [...combat.combatants].sort(compareCombatants);
+}

--- a/src/tools/handlers/combat.ts
+++ b/src/tools/handlers/combat.ts
@@ -3,6 +3,7 @@
  */
 
 import type { FoundryClient } from '../../foundry/client.js';
+import { getTurnOrder } from './combat-order.js';
 import { withToolError } from './utils.js';
 
 export async function handleGetCombatState(
@@ -18,8 +19,10 @@ export async function handleGetCombatState(
       };
     }
 
-    const combatants = combat.combatants
-      .sort((a, b) => (b.initiative ?? -999) - (a.initiative ?? -999))
+    // `combat` is a live reference into the world-data cache: sort a COPY via
+    // the shared helper so a read never reorders cached state (#214). The same
+    // helper backs `next_turn`, so both tools agree on what `combat.turn` means.
+    const combatants = getTurnOrder(combat)
       .map((c, i) => {
         const current = combat.turn === i ? ' <-- CURRENT' : '';
         const status = c.defeated ? ' [DEFEATED]' : c.hidden ? ' [HIDDEN]' : '';

--- a/src/tools/handlers/diagnostics.ts
+++ b/src/tools/handlers/diagnostics.ts
@@ -22,6 +22,15 @@ const MAX_LOG_LIMIT = 1000;
 const DEFAULT_SEARCH_LIMIT = 50;
 
 /**
+ * Shown whenever `FoundryClient.isWorldDataStale()` is set (#217): the cached
+ * world snapshot is still being served, but it stopped following live document
+ * changes when the socket dropped and nothing replays the gap.
+ */
+const STALE_WORLD_DATA_NOTICE =
+  '⚠️ **Stale:** this snapshot stopped following live changes when the connection dropped, ' +
+  'and document changes made since are missing. Run `refresh_world_data` to resync.';
+
+/**
  * Handles recent log retrieval requests
  *
  * Filtering is applied after fetching all logs from the underlying source:
@@ -335,6 +344,14 @@ ${diagnosis.recommendations.map((rec: string) => `- ${rec}`).join('\n')}
  * The system-health section reads the nested fields `SystemHealthSchema`
  * declares. Playtime is not reported: `getWorldInfo()` has no genuine source
  * for it and hard-codes 0.
+ *
+ * The world section carries {@link STALE_WORLD_DATA_NOTICE} whenever the cache
+ * has stopped following live document changes (#217). Reads keep being served
+ * from that snapshot, which is the right call — a flagged answer beats no
+ * answer — but rendering it bare presents a point-in-time copy as though it
+ * were live. It matters most right after an automatic reconnect, where the
+ * connection line legitimately reads "✅ Connected" while the cache is still
+ * missing every broadcast the outage swallowed.
  */
 export async function handleGetHealthStatus(
   _args: Record<string, unknown>,
@@ -346,6 +363,17 @@ export async function handleGetHealthStatus(
       foundryClient.getWorldInfo().catch(() => null),
       diagnosticsClient.getSystemHealth().catch(() => null),
     ]);
+
+    const worldLines = worldInfo
+      ? [
+          `- **Title:** ${worldInfo.title}`,
+          `- **System:** ${worldInfo.system}`,
+          `- **Core Version:** ${worldInfo.coreVersion}`,
+        ]
+      : ['ℹ️ Not available'];
+    if (foundryClient.isWorldDataStale()) {
+      worldLines.unshift(STALE_WORLD_DATA_NOTICE);
+    }
 
     let healthSection = 'ℹ️ Not available';
     if (systemHealth) {
@@ -377,14 +405,7 @@ export async function handleGetHealthStatus(
 ${foundryClient.isConnected() ? '✅ Connected' : '❌ Disconnected'}
 
 **World Information:**
-${
-  worldInfo
-    ? `
-- **Title:** ${worldInfo.title}
-- **System:** ${worldInfo.system}
-- **Core Version:** ${worldInfo.coreVersion}`
-    : 'ℹ️ Not available'
-}
+${worldLines.join('\n')}
 
 **System Health:**
 ${healthSection}`,

--- a/src/tools/handlers/diagnostics.ts
+++ b/src/tools/handlers/diagnostics.ts
@@ -6,6 +6,8 @@
 
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { DiagnosticsClient } from '../../diagnostics/client.js';
+import type { LogEntry } from '../../diagnostics/types.js';
+import { LogEntrySchema } from '../../diagnostics/types.js';
 import type { FoundryClient } from '../../foundry/client.js';
 import type { DiagnosticSystem } from '../../utils/diagnostics.js';
 import { withToolError } from './utils.js';
@@ -15,6 +17,9 @@ const VALID_LOG_LEVELS = new Set(['debug', 'info', 'warn', 'error', 'log', 'noti
 
 /** Hard upper bound on entries returned, regardless of caller-supplied limit */
 const MAX_LOG_LIMIT = 1000;
+
+/** Default number of search hits rendered when the caller supplies no limit */
+const DEFAULT_SEARCH_LIMIT = 50;
 
 /**
  * Handles recent log retrieval requests
@@ -102,7 +107,30 @@ ${logEntries || 'No log entries found.'}`,
 }
 
 /**
+ * Resolves a caller-supplied level string to a level the search endpoint accepts.
+ *
+ * The tool schema advertises `debug`, which has no counterpart in the log
+ * entry level enum; such values are dropped rather than sent upstream.
+ *
+ * @returns the normalized level, or `undefined` when unsupported/absent
+ */
+function resolveSearchLevel(level: string | undefined): LogEntry['level'] | undefined {
+  if (typeof level !== 'string' || level === '') {
+    return undefined;
+  }
+  const parsed = LogEntrySchema.shape.level.safeParse(level.toLowerCase());
+  return parsed.success ? parsed.data : undefined;
+}
+
+/**
  * Handles log search requests
+ *
+ * `searchLogs()` resolves to a `LogSearchResponse` object; matched entries live
+ * under `response.logs` and the upstream match count under `response.matches`.
+ *
+ * - `level`: forwarded to the search request when it names a real log level
+ * - `limit`: applied to the rendered entries (default 50, hard cap 1000); it
+ *   does not shrink the reported `matches` total
  */
 export async function handleSearchLogs(
   args: {
@@ -112,25 +140,32 @@ export async function handleSearchLogs(
   },
   diagnosticsClient: DiagnosticsClient,
 ) {
-  const { query, level } = args;
+  const { query, level, limit } = args;
 
   if (!query || typeof query !== 'string') {
     throw new McpError(ErrorCode.InvalidParams, 'Query is required and must be a string');
   }
 
+  const searchLevel = resolveSearchLevel(level);
+  const effectiveLimit = Math.min(Math.max(1, limit ?? DEFAULT_SEARCH_LIMIT), MAX_LOG_LIMIT);
+
+  let levelLabel = 'All levels';
+  if (searchLevel !== undefined) {
+    levelLabel = searchLevel;
+  } else if (level) {
+    levelLabel = `${level} (unsupported — not applied)`;
+  }
+
   return withToolError('search logs', async () => {
-    const logs = await diagnosticsClient.searchLogs({ pattern: query });
+    const response = await diagnosticsClient.searchLogs({
+      pattern: query,
+      ...(searchLevel !== undefined ? { level: searchLevel } : {}),
+    });
 
-    const logEntries = Array.isArray(logs)
-      ? logs
-          .map((log: unknown) => {
-            const logEntry = log as { timestamp?: string; level?: string; message?: string };
-            return `[${logEntry.timestamp || new Date().toISOString()}] **${(logEntry.level || 'INFO').toUpperCase()}** ${logEntry.message || String(log)}`;
-          })
-          .join('\n')
-      : 'No logs available';
-
-    const logCount = Array.isArray(logs) ? logs.length : 0;
+    const shown = response.logs.slice(0, effectiveLimit);
+    const logEntries = shown
+      .map((entry) => `[${entry.timestamp}] **${entry.level.toUpperCase()}** ${entry.message}`)
+      .join('\n');
 
     return {
       content: [
@@ -138,8 +173,11 @@ export async function handleSearchLogs(
           type: 'text',
           text: `🔍 **Log Search Results**
 **Query:** "${query}"
-**Level Filter:** ${level || 'All levels'}
-**Results:** ${logCount}
+**Level Filter:** ${levelLabel}
+**Limit:** ${effectiveLimit}
+**Timeframe:** ${response.searchTimeframe}
+**Matches:** ${response.matches}
+**Showing:** ${shown.length}
 
 ${logEntries || 'No matching log entries found.'}`,
         },

--- a/src/tools/handlers/diagnostics.ts
+++ b/src/tools/handlers/diagnostics.ts
@@ -187,7 +187,37 @@ ${logEntries || 'No matching log entries found.'}`,
 }
 
 /**
+ * Formats an uptime in seconds as a compact human-readable duration
+ */
+function formatUptime(seconds: number): string {
+  const total = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(total / 3600);
+  const minutes = Math.floor((total % 3600) / 60);
+  if (hours > 0) {
+    return `${hours}h ${minutes}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${total % 60}s`;
+  }
+  return `${total}s`;
+}
+
+/**
+ * Formats a byte count (as reported by `process.memoryUsage()`) in binary
+ * megabytes (MiB, the unit Node.js tooling conventionally labels "MB")
+ */
+function formatMegabytes(bytes: number): string {
+  return `${Math.round(bytes / (1024 * 1024))} MB`;
+}
+
+/**
  * Handles system health requests
+ *
+ * Every value rendered here is a field `SystemHealthSchema` actually declares.
+ * The schema strips unknown keys, so metrics it does not model (CPU, disk,
+ * response time, throughput) cannot be reported and are deliberately absent
+ * rather than rendered as a permanent `N/A`. Optional fields (`server.uptime`,
+ * `performance.memory`) are omitted when the server does not supply them.
  */
 export async function handleGetSystemHealth(
   _args: Record<string, unknown>,
@@ -195,24 +225,48 @@ export async function handleGetSystemHealth(
 ) {
   return withToolError('get system health', async () => {
     const health = await diagnosticsClient.getSystemHealth();
+    const { server, users, modules, performance, logs } = health;
+
+    const serverLines = [
+      `- **FoundryVTT Version:** ${server.foundryVersion}`,
+      `- **Game System:** ${server.systemVersion}`,
+      `- **World:** ${server.worldId}`,
+    ];
+    if (server.uptime !== undefined) {
+      serverLines.push(`- **Uptime:** ${formatUptime(server.uptime)}`);
+    }
+
+    const performanceLines = [`- **Connected Clients:** ${performance.connectedClients}`];
+    if (performance.memory) {
+      performanceLines.push(
+        `- **Memory (heap):** ${formatMegabytes(performance.memory.heapUsed)} used / ${formatMegabytes(performance.memory.heapTotal)} total`,
+        `- **Memory (RSS):** ${formatMegabytes(performance.memory.rss)}`,
+      );
+    }
 
     return {
       content: [
         {
           type: 'text',
           text: `🏥 **System Health Status**
-**Overall Status:** ${health.status || 'Unknown'}
-**CPU Usage:** ${(health as { cpu?: number }).cpu || 'N/A'}%
-**Memory Usage:** ${(health as { memory?: number }).memory || 'N/A'}%
-**Disk Usage:** ${(health as { disk?: number }).disk || 'N/A'}%
-**Uptime:** ${(health as { uptime?: number }).uptime || 'N/A'} seconds
+**Overall Status:** ${health.status}
+**Reported At:** ${health.timestamp}
 
-**Active Connections:** ${(health as { connections?: number }).connections || 'N/A'}
-**Last Error:** ${(health as { lastError?: string }).lastError || 'None'}
+**Server:**
+${serverLines.join('\n')}
 
-**Performance Metrics:**
-- **Response Time:** ${(health as { responseTime?: number }).responseTime || 'N/A'}ms
-- **Throughput:** ${(health as { throughput?: number }).throughput || 'N/A'} requests/sec`,
+**Sessions:**
+- **Users:** ${users.active} active / ${users.total} total (${users.gm} GM)
+- **Modules:** ${modules.active} active / ${modules.total} installed
+
+**Performance:**
+${performanceLines.join('\n')}
+
+**Logs:**
+- **Buffer:** ${logs.bufferSize} entries
+- **Recent Errors:** ${logs.recentErrors}
+- **Recent Warnings:** ${logs.recentWarnings}
+- **Error Rate:** ${logs.errorRate}%`,
         },
       ],
     };
@@ -277,6 +331,10 @@ ${diagnosis.recommendations.map((rec: string) => `- ${rec}`).join('\n')}
 
 /**
  * Handles comprehensive health status requests
+ *
+ * The system-health section reads the nested fields `SystemHealthSchema`
+ * declares. Playtime is not reported: `getWorldInfo()` has no genuine source
+ * for it and hard-codes 0.
  */
 export async function handleGetHealthStatus(
   _args: Record<string, unknown>,
@@ -289,11 +347,31 @@ export async function handleGetHealthStatus(
       diagnosticsClient.getSystemHealth().catch(() => null),
     ]);
 
+    let healthSection = 'ℹ️ Not available';
+    if (systemHealth) {
+      const healthLines = [
+        `- **Status:** ${systemHealth.status}`,
+        `- **Users:** ${systemHealth.users.active} active / ${systemHealth.users.total} total`,
+      ];
+      if (systemHealth.server.uptime !== undefined) {
+        healthLines.push(`- **Uptime:** ${formatUptime(systemHealth.server.uptime)}`);
+      }
+      if (systemHealth.performance.memory) {
+        healthLines.push(
+          `- **Memory (heap used):** ${formatMegabytes(systemHealth.performance.memory.heapUsed)}`,
+        );
+      }
+      healthLines.push(
+        `- **Recent Errors:** ${systemHealth.logs.recentErrors} (warnings: ${systemHealth.logs.recentWarnings})`,
+      );
+      healthSection = `\n${healthLines.join('\n')}`;
+    }
+
     return {
       content: [
         {
           type: 'text',
-          text: `🩺 **Comprehensive Health Status**
+          text: `\u{1FA7A} **Comprehensive Health Status**
 
 **FoundryVTT Connection:**
 ${foundryClient.isConnected() ? '✅ Connected' : '❌ Disconnected'}
@@ -304,21 +382,12 @@ ${
     ? `
 - **Title:** ${worldInfo.title}
 - **System:** ${worldInfo.system}
-- **Core Version:** ${worldInfo.coreVersion}
-- **Playtime:** ${Math.floor(worldInfo.playtime / 3600)} hours`
+- **Core Version:** ${worldInfo.coreVersion}`
     : 'ℹ️ Not available'
 }
 
 **System Health:**
-${
-  systemHealth
-    ? `
-- **Status:** ${systemHealth.status || 'Unknown'}
-- **CPU:** ${(systemHealth as { cpu?: number }).cpu || 'N/A'}%
-- **Memory:** ${(systemHealth as { memory?: number }).memory || 'N/A'}%
-- **Uptime:** ${Math.floor(((systemHealth as { uptime?: number }).uptime || 0) / 3600)} hours`
-    : 'ℹ️ Not available'
-}`,
+${healthSection}`,
         },
       ],
     };

--- a/src/tools/handlers/resources.ts
+++ b/src/tools/handlers/resources.ts
@@ -6,6 +6,7 @@ import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import type { DiagnosticsClient } from '../../diagnostics/client.js';
 import type { FoundryClient } from '../../foundry/client.js';
 import { logger } from '../../utils/logger.js';
+import { getTurnOrder } from './combat-order.js';
 import { withToolError } from './utils.js';
 
 export async function handleReadResource(
@@ -196,8 +197,22 @@ async function getUsersResource(foundryClient: FoundryClient) {
   };
 }
 
+/**
+ * Serves the active combat encounter (#214 follow-up).
+ *
+ * `Combat#turn` indexes the **initiative-sorted** turn order, and this resource
+ * is the id-bearing companion to `get_combat_state`, whose ordinals are printed
+ * in that same order. Emitting the raw cached `combatants` array — which is in
+ * creation order — next to that `turn` makes both `combat.combatants[turn]` and
+ * "the Nth combatant I just read" resolve to the wrong document, so the emitted
+ * `combatants` are re-ordered here through the shared `getTurnOrder()` helper.
+ *
+ * `getTurnOrder()` sorts a copy: the cached array is a live reference into
+ * worldData and must not be reordered as a side effect of a read.
+ */
 async function getCombatResource(foundryClient: FoundryClient) {
-  const combat = foundryClient.getCombatState();
+  const cached = foundryClient.getCombatState();
+  const combat = cached ? { ...cached, combatants: getTurnOrder(cached) } : cached;
   return {
     contents: [
       {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,5 @@
 {
-  "entryPoints": ["src/index.ts", "src/foundry/client.ts", "src/config/index.ts", "src/foundry/types.ts", "src/utils/logger.ts"],
+  "entryPoints": ["src/index.ts", "src/foundry/client.ts", "src/foundry/dice-formula.ts", "src/config/index.ts", "src/foundry/types.ts", "src/utils/logger.ts"],
   "out": "docs",
   "exclude": ["**/*.test.ts", "**/node_modules/**", "src/tools/**", "src/character/**", "src/combat/**", "src/resources/**"],
   "name": "FoundryVTT MCP Server",


### PR DESCRIPTION
Closes #214, closes #215, closes #216, closes #217, closes #218, closes #219.

These six were all filed off the same audit — cases where a tool description promised behaviour the handler did not deliver. #185 fixed the wording; this fixes the behaviour and then removes the wording that is no longer true.

## The fixes

### #214 — `Combat#turn` indexed two different orders

`computeNextTurn` treated `turn` as an index into creation order; `get_combat_state` resolved it against initiative order. Foundry uses initiative order, so the write path was the wrong one.

New `src/tools/handlers/combat-order.ts` is the single ordering source, mirroring core's `Combat._sortCombatants`: initiative descending, un-rolled initiative last, ties broken by `_id` so the order is total. The previous read-path comparator used a `-999` sentinel for null initiative, which mis-ordered any combatant below −999 and had no tiebreak.

Separately, `getCombatState()` returns a live reference into the world cache and `handleGetCombatState` was calling `.sort()` on it — a read permanently reordering cached state. It now sorts a copy, which also removes the order-of-calls dependency that made the disagreement intermittent.

Two follow-ons the issue asked for:

- **`set_initiative` now re-anchors `turn`.** Changing anyone's initiative can slide a different combatant under the stored index; core re-finds the acting combatant and updates `turn`, and so do we. The response gained a `Still acting:` line.
- **`foundry://combat` emits `combatants` in turn order.** The old in-place sort was accidentally masking this — fixing the mutation exposed that the resource always emitted creation order beside an initiative-indexed `turn`. Since `get_combat_state` points models at that resource for ids, a model reading "3. Bob" and taking `combatants[2]._id` got Charlie. Re-ordering the array beats adding a parallel `turnOrder`, which would have left the wrong list in the payload for `combat.combatants[turn]` to resolve against.

### #215 — `search_logs` returned nothing and ignored its arguments

`searchLogs()` resolves a `LogSearchResponse` object; the handler `Array.isArray`-checked it, so every call rendered `0` results regardless of what came back. Now reads `response.logs`, reports `response.matches`, and wires the two dropped parameters: `limit` is destructured and clamped, `level` is normalized and validated through `LogEntrySchema.shape.level` rather than cast.

`debug` is declared in the tool's input schema but is not in the log-entry enum, so it cannot be applied upstream — the header now says so explicitly instead of implying a filter that never ran.

The existing spec mocked `searchLogs` as returning a bare array, i.e. it encoded the bug. Rewritten against fixtures built through the real schema so it cannot drift again.

### #216 — health metrics read fields Zod strips

Both handlers read top-level keys that `SystemHealthSchema` does not declare, and `.parse()` strips unknown keys — so every metric rendered `N/A` even on good data. They now read the nested paths the schema actually defines (`performance.memory.*`, `server.uptime`, `users`, `logs`).

Seven lines had no backing field anywhere in the schema (CPU, disk, connections, last-error, response-time, throughput, top-level uptime) and were permanently `N/A`; they are removed rather than faked. Hard-coded `playtime: 0` is dropped from the report for the same reason. Optional fields are omitted when absent instead of printing a placeholder.

### #217 — `isConnected()` reported a flag nothing cleared

`_isConnected` was only ever cleared inside an explicit `disconnect()`; the sole `connect_error` listener was handshake-scoped. A dropped socket still read as `✅ Connected`, while `assertWriteable()` checked `socket?.connected` and correctly refused writes — the two paths disagreed.

Liveness now comes from the socket, with persistent `connect` and `disconnect` listeners torn down via `socket.off()` on every exit path. Review caught two follow-ons:

- The first attempt latched *off* instead. socket.io-client defaults to `reconnection: true`, so an auto-reconnect restored `socket.connected` but never the flag. A `connect` handler plus a `detachSocket()` helper fix that and stop a superseded socket clearing liveness for its replacement.
- **REST mode had the identical original bug**, and dropping the caveat globally had removed the warning covering it. REST liveness now tracks the last observed request outcome rather than latching on the connect probe.

The issue's second impact bullet — the world section rendering a stale cache as live — is also addressed: `isWorldDataStale()` had zero consumers, and reconnect deliberately does not replay missed broadcasts, so `get_health_status` now marks the world section when it is a stale snapshot.

### #218 — `activeUsers` froze at the initial snapshot

`activeUsers` is a top-level `WorldData` field, so the `modifyDocument` cache path (#208) never touched it — presence was only as fresh as the last full world load. Now updated from Foundry's `userActivity` broadcast, with the payload validated by a schema rather than a cast.

### #219 — the dice parser silently dropped terms

The char-class validator accepted more than the parse regex could represent, and the excess vanished from the total — `1d20 + 5`, `1d20+5+3`, `d20`, `2d6+1d4` all returned plausible but wrong numbers. For a dice roller that is worse than an error, since nothing signals the formula was misread.

New `src/foundry/dice-formula.ts` tokenizes dice terms and standalone constants so all of those evaluate correctly; anything it cannot represent throws instead of being dropped. Table-driven tests with a stubbed RNG assert exact totals, not ranges.

Validation is now **per transport**, which matters: the first attempt ran the local parser ahead of the transport branch and so imposed the fallback's narrower grammar on REST, where Foundry's own engine evaluates `(1d20+5)` fine. REST keeps that capability and gets an alphabet check that reports the offending character by name and position, so both transports are equally specific about what they refuse. The REST response body is validated with Zod — a 200 carrying no numeric `total` used to yield `total: undefined` while the type claimed `number`.

## Docs

Each issue ended with "once fixed, drop the caveat." Those caveats are now false, and a false warning in a model-facing tool description degrades tool selection exactly as much as a false promise. Removed across `src/tools/definitions.ts`, `README.md` and `SETUP_GUIDE.md` — except where a limitation genuinely survives (no CPU field exists, playtime has no real source), which stays documented.

## Testing

**367 → 519 passing**, two new test files. No existing test deleted or loosened: no `.skip`/`.only`/`.todo` added anywhere, and the four removed test declarations are all in `search_logs.test.ts`, which went 6 → 16 in a rewrite because the old cases asserted the pre-fix bare-array contract.

Every fix was checked by reverting the production change in a scratch tree and confirming the new tests fail against the old behaviour — a test green in both states proves nothing. That check earned its keep twice:

- A test asserted the `set_initiative` turn-drift **as intended behaviour** rather than catching it.
- Fixtures were inventing `combat.started`, which FoundryVTT never persists — it is a client-side getter, not schema data. `WorldCombat.started` was typed as required, so `tsc` hid it. Started-ness is now derived (`round > 0 && combatants.length > 0`) and the field is optional with a warning. Without this the whole `set_initiative` re-anchor would have silently no-op'd in production while its tests passed.

`tsc --noEmit`, `bun run build`, `biome check` and `docs:check` all clean; the 11 remaining biome warnings and 3 typedoc warnings are byte-identical on `main`. Suite verified stable across repeated full runs.

Integration and E2E tiers were not run — they need a live FoundryVTT container (still blocked on #183).

## Notes for review

- `src/combat/manager.ts` has the only other turn-indexing code, with a comparator that diverges from `combat-order.ts` (un-rolled initiative sorts mid-table, no tiebreak) and an in-place sort. It has **zero importers** — confirmed dead. Left alone: worth deciding whether to delete it or point it at `combat-order.ts` before anyone revives it.
- `.husky/pre-commit` hard-fails with a bare `exit 1` when `gitleaks` is absent, which it is in a fresh container, with no hint what to install. All commits here went through the real hook; `gitleaks detect` over the full branch reports no leaks.
- `.github/workflows/docs.yml` runs typedoc two ways — the deploy step passes an explicit file list, `docs:check` uses `typedoc.json`'s `entryPoints`. The sets differ, so `dice-formula` is gate-checked but won't appear in published docs. Same drift class that caused a regression mid-branch.
- `playtime` remains on the `WorldInfo` type as an always-zero field. Dropping it from the report satisfies #216, but it is a trap for the next consumer.
- `handleSetInitiative` now makes two sequential writes under one error wrapper, so a failure in the `turn` re-anchor reports as "Failed to set combatant initiative" even though the initiative write succeeded. Known, left as-is — splitting the message seemed like more surface than the case warrants, but say the word.