### PR TITLE
test(integration): pin the test tier to FoundryVTT 14.367

### DIFF
--- a/.claude/rules/foundry-write-protocol.md
+++ b/.claude/rules/foundry-write-protocol.md
@@ -73,17 +73,24 @@ documented on the web** (the wiki is JS-rendered). The authoritative source is
 the actual app, shipped unminified under `data/container_cache/foundryvtt-<ver>.zip`:
 
 ```
-FOUNDRY_VERSION=$(grep -oE 'FOUNDRY_VERSION:-[0-9.]+' docker-compose.test.yml | cut -d- -f2)
-unzip -o -q "data/container_cache/foundryvtt-${FOUNDRY_VERSION}.zip" 'resources/app/client/data/client-backend.mjs' -d /tmp/fvtt
+unzip -o -q ../foundryvtt-harness/data/container_cache/foundryvtt-13.348.zip 'resources/app/client/data/client-backend.mjs' -d /tmp/fvtt
 ```
 
-Read the version out of the pin rather than hardcoding it — the pin moves, and
-a hardcoded path sends the next reader to a zip the cache no longer holds.
+That cache belongs to the sibling **foundryvtt-harness** checkout, not to this
+repo — run the command from the `foundryvtt-mcp` root. It holds exactly one
+build, `foundryvtt-13.348.zip`, and the version is hardcoded here because it
+names the file that is actually present rather than the version this repo pins.
 
 **Current state of this verification:** the shape implemented in `client.ts` was
-read out of the **v13.348** client source. `docker-compose.test.yml` now pins
-**14.367**, and the shape has not been re-read against it. Run the procedure
-above before relying on the write tools against a v14 server.
+read out of that **v13.348** source. `docker-compose.test.yml` now pins
+**14.367**, and the shape has not been re-read against it.
+
+Re-reading it at 14.367 needs a v14 zip, and nothing here produces one. The test
+container uses tmpfs `/data` with `CONTAINER_PRESERVE_CONFIG=false`, so it never
+persists a cache; the harness is the only checkout that does, and it must stay on
+13.348 — a v14 first launch migrates its live worlds irreversibly. Obtain the
+build another way (a throwaway felddy container with a scratch data volume, or a
+direct licensed download) before trusting the write tools on a v14 server.
 
 Key files: `client/data/client-backend.mjs` (`#buildRequest`/`#dispatchRequest`),
 `client/helpers/socket-interface.mjs` (`dispatch` = emit-with-ack), and

--- a/.claude/rules/foundry-write-protocol.md
+++ b/.claude/rules/foundry-write-protocol.md
@@ -73,8 +73,17 @@ documented on the web** (the wiki is JS-rendered). The authoritative source is
 the actual app, shipped unminified under `data/container_cache/foundryvtt-<ver>.zip`:
 
 ```
-unzip -o -q data/container_cache/foundryvtt-13.348.zip 'resources/app/client/data/client-backend.mjs' -d /tmp/fvtt
+FOUNDRY_VERSION=$(grep -oE 'FOUNDRY_VERSION:-[0-9.]+' docker-compose.test.yml | cut -d- -f2)
+unzip -o -q "data/container_cache/foundryvtt-${FOUNDRY_VERSION}.zip" 'resources/app/client/data/client-backend.mjs' -d /tmp/fvtt
 ```
+
+Read the version out of the pin rather than hardcoding it — the pin moves, and
+a hardcoded path sends the next reader to a zip the cache no longer holds.
+
+**Current state of this verification:** the shape implemented in `client.ts` was
+read out of the **v13.348** client source. `docker-compose.test.yml` now pins
+**14.367**, and the shape has not been re-read against it. Run the procedure
+above before relying on the write tools against a v14 server.
 
 Key files: `client/data/client-backend.mjs` (`#buildRequest`/`#dispatchRequest`),
 `client/helpers/socket-interface.mjs` (`dispatch` = emit-with-ack), and

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -19,8 +19,10 @@ local/CI parity.
   (`createConnectedClient`) in Socket.IO mode (`FOUNDRY_USERNAME`/`FOUNDRY_PASSWORD`).
 - The Foundry build under test is pinned **twice** in `docker-compose.test.yml`
   — the `image:` tag and `FOUNDRY_VERSION` — and the env var is the one that
-  decides what installs. Move both together; a `FOUNDRY_VERSION` left in a
-  local `.env.integration` overrides both.
+  decides what installs. Move both together. To override for one run, export
+  `FOUNDRY_VERSION` in the shell; setting it in `.env.integration` does nothing,
+  because compose interpolation never reads an `env_file:` entry and the
+  `environment:` block overrides it regardless.
 - `tests/integration/global-setup.ts` only **waits** for the container at
   `:30001` — it does **not** start it.
 - **Running it:** needs (a) `.env.integration` (copy from

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -17,6 +17,10 @@ local/CI parity.
 
 - Connects through the shared helper `tests/integration/setup.ts`
   (`createConnectedClient`) in Socket.IO mode (`FOUNDRY_USERNAME`/`FOUNDRY_PASSWORD`).
+- The Foundry build under test is pinned **twice** in `docker-compose.test.yml`
+  — the `image:` tag and `FOUNDRY_VERSION` — and the env var is the one that
+  decides what installs. Move both together; a `FOUNDRY_VERSION` left in a
+  local `.env.integration` overrides both.
 - `tests/integration/global-setup.ts` only **waits** for the container at
   `:30001` — it does **not** start it.
 - **Running it:** needs (a) `.env.integration` (copy from

--- a/.env.integration.example
+++ b/.env.integration.example
@@ -11,9 +11,9 @@ FOUNDRY_PASSWORD=test-password
 # FoundryVTT URL (matches docker-compose.test.yml port mapping)
 FOUNDRY_URL=http://localhost:30001
 
-# Optional: which FoundryVTT core build the container downloads and installs.
-# docker-compose.test.yml reads this file as `env_file`, so anything set here
-# OVERRIDES the pin in that file. Leave it unset to follow the repo pin; set it
-# only to test another build. A stale value left here after the repo pin moves
-# is why a version bump can appear not to take effect.
-# FOUNDRY_VERSION=14.367
+# Do NOT set FOUNDRY_VERSION here -- it would have no effect. Compose resolves
+# `${FOUNDRY_VERSION:-...}` in docker-compose.test.yml from the shell environment
+# and a project-root `.env`, never from an `env_file:` entry, and the value in
+# that file's `environment:` block overrides `env_file:` in any case.
+# To run the tier against another build, export it for the one command:
+#   FOUNDRY_VERSION=14.368 just test-integration-docker

--- a/.env.integration.example
+++ b/.env.integration.example
@@ -10,3 +10,10 @@ FOUNDRY_PASSWORD=test-password
 
 # FoundryVTT URL (matches docker-compose.test.yml port mapping)
 FOUNDRY_URL=http://localhost:30001
+
+# Optional: which FoundryVTT core build the container downloads and installs.
+# docker-compose.test.yml reads this file as `env_file`, so anything set here
+# OVERRIDES the pin in that file. Leave it unset to follow the repo pin; set it
+# only to test another build. A stale value left here after the repo pin moves
+# is why a version bump can appear not to take effect.
+# FOUNDRY_VERSION=14.367

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,14 +1,26 @@
 services:
   fvtt-test:
-    image: felddy/foundryvtt:13
+    image: felddy/foundryvtt:14
     ports:
       - "30001:30000"
     environment:
       - FOUNDRY_LICENSE_KEY=${FOUNDRY_LICENSE_KEY}
-      # Pin the build so integration tests always run against the version the
-      # modifyDocument wire shape is verified against (client.ts), instead of
-      # whatever "latest" felddy resolves to (which also risks 429 rate-limits).
-      - FOUNDRY_VERSION=${FOUNDRY_VERSION:-13.348}
+      # TWO pins, and FOUNDRY_VERSION is the one that decides. The felddy image
+      # ships no Foundry: it downloads the build named by FOUNDRY_VERSION at
+      # container start, so the `image:` tag above only supplies a default.
+      # Changing one without the other silently runs the old core on the new
+      # image — always move both together.
+      #
+      # Pinned to an exact build rather than "latest"/"release" so a run is
+      # reproducible and does not depend on whatever felddy resolves that day
+      # (which also risks foundryvtt.com 429 rate-limits).
+      #
+      # NOTE: the modifyDocument wire shape in src/foundry/client.ts was
+      # verified against the v13.348 client source and has NOT been re-verified
+      # against 14.367. Re-run the procedure in
+      # .claude/rules/foundry-write-protocol.md before trusting the write tools
+      # on this pin.
+      - FOUNDRY_VERSION=${FOUNDRY_VERSION:-14.367}
       - FOUNDRY_ADMIN_KEY=integration-test-admin
       - FOUNDRY_USERNAME=${FOUNDRY_USERNAME:-test-user}
       - FOUNDRY_PASSWORD=${FOUNDRY_PASSWORD:-test-password}

--- a/tests/e2e/helpers/foundry-helpers.ts
+++ b/tests/e2e/helpers/foundry-helpers.ts
@@ -8,24 +8,45 @@ export class FoundryTestHelpers {
   constructor(private page: Page) {}
 
   /**
-   * Handle FoundryVTT login if login form is present
+   * Handle FoundryVTT login if login form is present.
+   *
+   * The user control on the world join page differs by Foundry major version,
+   * and neither version can be exercised here (the integration and E2E tiers
+   * do not run in CI — issue #183), so match BOTH rather than swapping one
+   * hardcoded name for another:
+   *
+   * - v13 renders `<select name="userid">`, a dropdown of the world's users.
+   *   The previous `input[name="userid"]` selector never matched it.
+   * - v14.366 replaced that with a text input offering username
+   *   autocompletion, and uses camelCase `userId` — the same casing change
+   *   issue #222 reports for the POST /join request body.
    */
   async loginIfRequired(): Promise<void> {
     const loginForm = this.page.locator('#login-form, form[action="/join"]');
-    
+
     if (await loginForm.isVisible()) {
-      const usernameField = this.page.locator('input[name="userid"], input[name="username"]');
+      const username = process.env.FOUNDRY_USERNAME || 'admin';
+      // `.first()` keeps these out of Playwright strict mode while both the
+      // v13 and v14 shapes are listed.
+      const userSelect = this.page
+        .locator('select[name="userId"], select[name="userid"]')
+        .first();
+      const userInput = this.page
+        .locator('input[name="userId"], input[name="userid"], input[name="username"]')
+        .first();
       const passwordField = this.page.locator('input[name="password"]');
       const loginButton = this.page.locator('button[type="submit"], input[type="submit"]');
-      
-      if (await usernameField.isVisible()) {
-        await usernameField.fill(process.env.FOUNDRY_USERNAME || 'admin');
+
+      if (await userSelect.isVisible()) {
+        await userSelect.selectOption({ label: username });
+      } else if (await userInput.isVisible()) {
+        await userInput.fill(username);
       }
-      
+
       if (await passwordField.isVisible()) {
         await passwordField.fill(process.env.FOUNDRY_PASSWORD || 'admin');
       }
-      
+
       await loginButton.click();
       await this.page.waitForLoadState('networkidle');
     }


### PR DESCRIPTION
## What

Moves the integration test tier from FoundryVTT 13.348 to 14.367, the current
stable release.

- `docker-compose.test.yml`: `image: felddy/foundryvtt:13` → `:14`, and
  `FOUNDRY_VERSION` default `13.348` → `14.367`.
- `tests/e2e/helpers/foundry-helpers.ts`: the login helper matches both the v13
  and v14 shapes of the user field.
- `.claude/rules/foundry-write-protocol.md`: the client-source verification
  command names the sibling harness checkout that actually holds the cache, and
  records that no v14 zip can be produced here.
- `.claude/rules/testing.md` and the integration env example: document that the
  pin has two halves, and that overriding the version needs an exported
  variable -- setting it in the env file is silently ignored.

## Why

The `13` tag stopped moving at 13.351 in 2025-11 and the pin sat at 13.348 from
2025-08, so the tier targeted a build a year behind current stable.

**The version is pinned twice and only one of the two decides.** The felddy
image ships no Foundry — it downloads the build named by `FOUNDRY_VERSION` at
container start, so the `image:` tag only supplies a default. Bumping the tag
alone (the diff Renovate's dashboard entry #189 would have produced) yields a
v14 container that installs 13.348: a change that boots, passes its healthcheck,
and tests the old core. Both lines move together here.

The E2E login helper matched `input[name="userid"]` only. That never matched v13
either — v13 renders `<select name="userid">` — and v14.366 replaced the control
with a text input using camelCase `userId`, the same casing change #222 reports
for the POST /join request body. Since neither version can be run from this
repo, the selector now lists both field names and handles both control types
rather than swapping one hardcoded name for another.

## How

Verified the tag independently against the Docker Hub API: `14`, `14.367`,
`14.367.0`, `release` and `latest` are one build pushed 2026-08-19; `13` and
`13.351` last moved 2025-11-15.

Gates run:

- `just qa` (biome + `tsc --noEmit` + 519 unit tests) — exit 0, 28 files passed,
  11 pre-existing biome warnings, none in the files this PR touches.
- `tests/e2e/helpers/foundry-helpers.ts` typechecked directly (`tsc --noEmit
  --ignoreConfig --strict --types node`, exit 0) because `tsconfig.json` scopes
  to `src/**` and biome ignores `tests/e2e`, so `just qa` reads neither.
- `docker-compose.test.yml` parsed and both pins read back.

## Not verified

**No v14 container was started by this PR, and none will be by CI.** The
integration job is gated on `FOUNDRY_LICENSE_KEY` / `FOUNDRY_USERNAME` /
`FOUNDRY_PASSWORD`, which the repo does not have, so the tier reports `skipped`
on every run (#183). `just qa` reads neither `docker-compose.test.yml` nor
`tests/e2e`. A green check on this PR means the YAML parses and the unit tier
still passes — nothing more.

Specifically unestablished:

- That a v14.367 container boots, installs, and becomes healthy here.
- That the `modifyDocument` wire shape in `src/foundry/client.ts` is unchanged
  at v14. It was read out of the v13.348 client source and is undocumented for
  external clients, so its absence from the 14.x release notes is not evidence
  of stability. The re-verification procedure is in
  `.claude/rules/foundry-write-protocol.md`; the comments in `client.ts` still
  say v13.348 because that is still the version they were verified against.
- That the E2E selector change matches a real v14 join page. The helper is also
  imported by no spec, so no test exercises it either way.
- That `worldData`, the Scene schema, or `getJoinData` keep their v13 shapes at
  v14. `tests/integration/contracts.integration.test.ts` is where that would
  surface first.

## Sequencing

On a v14 container the 4-step auth in `src/foundry/auth.ts` fails at step 3
until #222 lands, and every integration spec routes through
`createConnectedClient`. This PR should merge after, or together with,
`fix/222-join-userid-casing`; landing it first turns the tier from skipped to
uniformly red for anyone running it locally. `auth.ts` and its unit test are
untouched here.

Supersedes the pending "update felddy/foundryvtt docker tag to v14" entry on the
Renovate dashboard (#189), which would have moved only the image tag.

The sibling `foundryvtt-harness` checkout deliberately stays on 13.348: it
bind-mounts live worlds with `CONTAINER_PRESERVE_CONFIG=true`, and a v14 first
launch migrates them irreversibly. Nothing in it was read beyond its compose
file, and nothing was changed or started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFeGUDXpZH73SxytPfcKCf

