### PR TITLE
fix(auth): send the join user id under both key spellings

### DIFF
--- a/src/foundry/__tests__/auth.test.ts
+++ b/src/foundry/__tests__/auth.test.ts
@@ -319,3 +319,44 @@ describe('authenticateFoundry — rejected /join is reported, not thrown raw (#2
     ).rejects.toThrow('FoundryVTT authentication failed (HTTP 200): You may not join this world');
   });
 });
+
+describe('authenticateFoundry — POST /join body key spellings (#222)', () => {
+  /**
+   * The /join body key is a wire-format contract: the server destructures it by
+   * name and never validates a schema, so a key it does not read is silently
+   * undefined rather than rejected. Both spellings are sent, and this test pins
+   * both — a later "cleanup" of the apparent duplicate must go red.
+   *
+   * Driven through the display-name path so the posted value is the *resolved*
+   * document _id rather than the caller's input. The existing assertions cannot
+   * make that distinction: they read back the same local variable auth.ts posts.
+   */
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockJoinCookieResponse();
+    mockJoinPostSuccess();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('posts the resolved document _id under BOTH userid and userId', async () => {
+    const { socket } = buildMockSocket([{ _id: 'resolvedDocId123', name: 'Gamemaster' }]);
+    mockIo.mockReturnValue(socket);
+
+    await authenticateFoundry('http://localhost:30000', 'Gamemaster', 'pw');
+
+    expect(mockAxios.post).toHaveBeenCalledWith(
+      'http://localhost:30000/join',
+      {
+        action: 'join',
+        userid: 'resolvedDocId123',
+        userId: 'resolvedDocId123',
+        password: 'pw',
+      },
+      expect.any(Object),
+    );
+  });
+});

--- a/src/foundry/auth.ts
+++ b/src/foundry/auth.ts
@@ -163,7 +163,16 @@ export async function authenticateFoundry(
     `${baseUrl}/join`,
     {
       action: 'join',
+      // Both spellings are deliberate — do not "de-duplicate" them (#222).
+      // sessions.authenticateUser destructures the id straight off the body and
+      // never validates a schema, so the spelling it does not read is simply
+      // undefined and the other is ignored. Reading the shipped server bundles:
+      // v13.348 and v14.364 both take `{ userid, password }`; #222 reports
+      // v14.367 taking `{ userId, password }`. A key the server does not read
+      // yields `db.User.get(undefined)` → HTTP 401 JOIN.ErrorUserDoesNotExist,
+      // so sending only one spelling breaks whichever generation wants the other.
       userid: userId,
+      userId: userId,
       password,
     },
     {


### PR DESCRIPTION
## What

The `POST /join` body now carries the resolved user document `_id` under both
`userid` and `userId`. A unit test pins both spellings with a strict `toEqual` on
the whole body, so dropping either one goes red.

## Why

FoundryVTT's `sessions.authenticateUser` destructures the id straight off the
request body and never validates a schema. A server generation that reads the
spelling we do not send gets `undefined`, `db.User.get(undefined)` finds nothing,
and the join is refused with `HTTP 401 JOIN.ErrorUserDoesNotExist` — however
correct the credentials and the freshly resolved `_id` are. That is the failure
#222 reports.

**The evidence, and its confidence level.** I read the join handler out of the
shipped server bundles rather than working from the issue text:

| Version | `authenticateUser` destructure | How verified |
|---|---|---|
| 13.348 | `{userid: i, password: r} = s.body` | first-hand, `dist/sessions.mjs` from the bundle the harness pins |
| 14.364 | `{userid: i, password: r} = s.body` | first-hand, `dist/sessions.mjs` from `FoundryVTT-Node-14.364.zip` |
| 14.367 | `{userId, password}` per the issue | **not verified here** — no 14.367 bundle available |

So the lowercase spelling is confirmed on two shipped versions, including one in
the v14 line. That is why this PR does not take the swap the issue suggests:
renaming the key outright would fix 14.367 and break 13.348 and 14.364. Note
that #226 has since moved the integration tier from `felddy/foundryvtt:13` to
14.367, so the tier is no longer the v13 stakeholder it was when this PR was
opened -- but every user still on a v13 or early-v14 server is.

The v14.367 half rests on the reporter's account, which is nonetheless strong
evidence: they reverted and reapplied the one-line patch against a live
v14.367.0 server and the 401 tracked the patch each way. Two readings fit — the
key was renamed somewhere between 14.364 and 14.367, or the diagnosis is a
misattribution and the real cause is elsewhere. Worth noting for the second
reading: 14.364 *does* contain a camelCase `const {userId: a} = s.body`, but in
`loginAsUser`, which serves `action: "loginAs"`, not `action: "join"`.

**The error string moved in v14, and the symptom is identical either way.**
`JOIN.ErrorUserDoesNotExist` appears once in 13.348's `dist/sessions.mjs`,
immediately after `db.User.get(i)` (`if(!n) return e.status(401), e.send(...)`),
and **zero** times in 14.364's -- control on the same file, `JOIN.ErrorInvalidPassword`
is present in both, so the grep works. In 14.364 the string lives in
`dist/packages/world.mjs`: `async canJoin(e){ if(!e) throw new Error("JOIN.ErrorUserDoesNotExist") ...}`,
and `authenticateUser` catches it and re-sends it as the 401 body. So an
unreadable id produces the same HTTP 401 and the same message on both versions,
by two different routes -- the symptom alone cannot identify which version, or
which cause, is in play.

That leaves the reporter's revert/reapply test as the discriminator, and it
points one way: switching to camelCase *fixed* their 14.367 server. Had 14.367
still read lowercase, that switch would have broken a working join rather than
repairing a failing one. A rename somewhere between 14.364 and 14.367 is
therefore the reading their evidence supports, even though the quoted line does
not match the 14.364 bundle.

Sending both keys removes the need to settle it. It is correct under either
reading, and it is why the unverified half does not block the fix.

## How

Safe on every version examined because nothing rejects the extra field: the
`/join` route mounts a bare `express.json()` with no schema validation, and the
handler destructures rather than allowlists. Each server reads the spelling it
wants and ignores the other.

A comment at the call site names the versions and the concrete server-side
mechanism, since `userid: userId, userId: userId` reads as a typo and is a prime
target for a cleanup that would reintroduce the bug.

Version detection was considered and rejected. The release is available from
`getJoinData`, so it is technically reachable, but it buys nothing over two
fields while adding a branch, a dependency on an undocumented release object, and
a new "unknown version ⇒ which key?" failure mode. It only becomes worth
revisiting if a future Foundry starts rejecting unknown body keys.

## Test

`src/foundry/__tests__/auth.test.ts` gains one test asserting the exact body
shape. Two deliberate choices give it teeth:

- **Strict `toEqual`, not `expect.objectContaining`.** The pre-existing
  assertion at `:203` uses `objectContaining`, which matches a subset — it
  passes whether or not `userId` is present, so it could not pin this fix. It is
  left as-is; it still guards the lowercase key, and it does not contradict the
  new behaviour.
- **Driven through the display-name path** (`Gamemaster` → `resolvedDocId123`),
  so input and expected value differ and the test pins that the *resolved* `_id`
  is posted. Existing tests cannot distinguish that, because they read back the
  same local variable `auth.ts` posts.

Mutation-checked rather than assumed — each mutation applied and the suite
actually run:

| Mutation | `tsc` | Result |
|---|---|---|
| Delete `userId: userId,` (exact pre-fix state) | clean, exit 0 | 1 failed, 519 passed |
| Swap to camelCase only (the fix #222 suggests) | clean, exit 0 | new test **and** the existing `:203` assertion fail |

Both reds are the test's own, not the typechecker's. Restored: 520 passed.

`just qa` (biome + `tsc --noEmit` + vitest) exits 0. Its 11 biome warnings are
pre-existing in files this PR does not touch. The integration tier was not run —
it needs a live Foundry container and credentials.

## Follow-ups (not in this PR)

Surfaced by an audit of `src` for the same defect class — a name that must match
a server contract with nothing verifying it. Filing separately:

- **No CI gate can catch a repeat of this.** The integration tier pins v13 only,
  and is skipped in CI while the `FOUNDRY_*` secrets are absent (#183). Even
  fully wired it could only catch the v13-break direction. A `FOUNDRY_VERSION`
  matrix over a v13 and a v14 container is the durable answer.
- **REST mode reports connected against a server with no REST module.** The
  `x-api-key` header name appears once in `src`, untested, and the connect probe
  hits `/api/status` — which core Foundry serves *unauthenticated*. A wrong
  header or key still sets `_isConnected = true`. `rollDice` then silently falls
  back to a local roll on the resulting failures.
- **`/api/status` has two contradictory contracts in-tree**, and core's actual
  payload matches neither: `client.ts` treats any 2xx as connected, while
  `diagnostics.ts` requires a `status` field that core does not return.
- **The `sessionSocketOptions` doc comment states only v14 behaviour as
  universal.** v13 reads the session from `handshake.query`, v14 from the Cookie
  header; the code sends both, so the redundancy is load-bearing. The comment
  does say the query param "is kept for servers that read it", but asserts
  cookie-only resolution as universal and never names v13 as the reason. A
  reader trusting that would drop the query param and break v13 with the #206
  symptom.
- **A 16-character alphanumeric username short-circuits id resolution** on shape
  alone (`auth.ts:71`), producing this exact 401 with no lookup — a competing
  explanation for #222 that is cheap to rule out by asking the reporter for
  their username length.
- **`WorldDataSchema.safeParse`'s verdict is discarded**; a renamed top-level key
  degrades to empty arrays behind a single `logger.warn`.
- **`socketPath` is configured, defaulted and plumbed through three files but
  never reaches `io()`** — it breaks any Foundry behind a `routePrefix`.

Refs #222 — deliberately not `Closes`. The change is a provable no-op on both
versions that could be read here, so it only helps if 14.367 genuinely renamed
the key. If the reporter's 401 has a different cause — the 16-character-username
short-circuit below is a live candidate — auto-closing would bury it. Close #222
once the reporter confirms against 14.367, or once a 14.367 bundle is read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFeGUDXpZH73SxytPfcKCf


