### PR TITLE
fix(deps): raise the fast-uri and qs overrides to their patched versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
     "@hono/node-server": "^2.0.5",
     "brace-expansion": "^5.0.9",
     "express-rate-limit": "^8.5.1",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.6",
     "form-data": "^4.0.6",
     "hono": "^4.12.34",
     "ip-address": "^10.3.1",
@@ -40,7 +40,7 @@
     "path-to-regexp": "^8.4.2",
     "picomatch": "^4.0.4",
     "postcss": "^8.5.23",
-    "qs": "^6.15.2",
+    "qs": "^6.16.0",
     "rollup": "^4.60.3",
     "socket.io-parser": "^4.2.7",
     "vite": "^7.3.5",
@@ -329,7 +329,7 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
-    "fast-uri": ["fast-uri@3.1.5", "", {}, "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw=="],
+    "fast-uri": ["fast-uri@3.1.7", "", {}, "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -473,7 +473,7 @@
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
-    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+    "qs": ["qs@6.16.0", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA=="],
 
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
@@ -503,7 +503,7 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
 
     "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
 

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "express-rate-limit": "^8.5.1",
     "ip-address": "^10.3.1",
     "path-to-regexp": "^8.4.2",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.6",
     "socket.io-parser": "^4.2.7",
     "vite": "^7.3.5",
     "rollup": "^4.60.3",
@@ -111,7 +111,7 @@
     "form-data": "^4.0.6",
     "ws": "^8.21.0",
     "markdown-it": "^14.2.0",
-    "qs": "^6.15.2"
+    "qs": "^6.16.0"
   },
   "lint-staged": {
     "src/**/*.{ts,tsx,js,jsx}": [


### PR DESCRIPTION
## What

Raise two entries in the `overrides` block to their patched versions:

| Override | Was | Now | Clears |
|---|---|---|---|
| `fast-uri` | `^3.1.5` | `^3.1.6` | 4 high |
| `qs` | `^6.15.2` | `^6.16.0` | 2 moderate |

## Why

`security.yml` runs `bun audit --audit-level=moderate`, and that check has been
red on `main` since 2ee9aff — the run of 2026-09-04T14:32Z. It is not a flake and
not caused by any open PR: the same failure appears on every branch cut from
main, which is why it shows on #227 and showed on #226.

The six advisories are all in packages this repo already pins through
`overrides`, at versions below the fix:

- `fast-uri` — SSRF via malformed IPv6 normalization
  ([GHSA-f65p-4m7j-42xc](https://github.com/advisories/GHSA-f65p-4m7j-42xc)) and
  via repeated hostname percent-decoding
  ([GHSA-fph4-wmhf-6fwf](https://github.com/advisories/GHSA-fph4-wmhf-6fwf));
  host confusion via percent-encoded scheme normalization
  ([GHSA-jqff-g426-hqxp](https://github.com/advisories/GHSA-jqff-g426-hqxp)) and
  via skipped IDN canonicalization on scheme-relative references
  ([GHSA-5jgf-p345-68v8](https://github.com/advisories/GHSA-5jgf-p345-68v8)).
  All fixed in 3.1.6.
- `qs` — array-limit bypass via bracket-key comma parsing
  ([GHSA-x5fp-wj9c-mxmx](https://github.com/advisories/GHSA-x5fp-wj9c-mxmx)) and
  DoS via attacker-controlled `isBuffer`
  ([GHSA-4mjr-xmp4-gh2g](https://github.com/advisories/GHSA-4mjr-xmp4-gh2g)).
  Fixed in 6.16.0.

## How

Both bumps stay within the existing major, so no transitive consumer sees a range
change and only the resolved version moves in `bun.lock`.

This is deliberately **not** the `fast-uri` v4 entry on the Renovate dashboard
(#189). An `overrides` entry rewrites the version every transitive consumer
resolves, so a major there forces v4 onto packages that asked for v3 — a wider
change than these advisories require, and one that should be evaluated on its own.

## Verification

- `bun audit --audit-level=moderate` → exit 0, "No vulnerabilities found (checked
  268 packages, 2 below --audit-level=moderate)". Before the bump: exit 1, 4 high
  and 2 moderate.
- `just qa` (biome + `tsc --noEmit` + vitest) → exit 0, 28 files / 519 tests.

Two `low` advisories remain and are untouched, both below the gate's threshold:
`body-parser` (needs >=2.3.0) and `esbuild` (needs >=0.28.1, and only affects the
dev server on Windows). Neither is currently an override, so clearing them would
mean adding pins for findings the gate does not check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JFeGUDXpZH73SxytPfcKCf
